### PR TITLE
refactor all

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     apoc
     pyclesperanto_prototype
     dask
-    functools
     napari_workflows
 
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ install_requires =
     apoc
     pyclesperanto_prototype
     dask
+    functools
+    napari_workflows
 
 python_requires = >=3.8
 include_package_data = True

--- a/src/napari_ndev/__init__.py
+++ b/src/napari_ndev/__init__.py
@@ -3,10 +3,16 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-from ._widget import batch_annotator, batch_predict, batch_training
+from ._widget import (
+    batch_annotator,
+    batch_predict,
+    batch_training,
+    batch_workflow,
+)
 
 __all__ = [
     "batch_annotator",
+    "batch_workflow",
     "batch_training",
     "batch_predict",
 ]

--- a/src/napari_ndev/_tests/test_widget.py
+++ b/src/napari_ndev/_tests/test_widget.py
@@ -1,7 +1,7 @@
 import numpy as np
 from aicsimageio import AICSImage
 
-from napari_ndev import batch_annotator  # , batch_predict, batch_training
+# from napari_ndev import batch_annotator  # , batch_predict, batch_training
 
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object
@@ -17,5 +17,5 @@ def test_batch_annotator(make_napari_viewer, capsys):
     viewer.add_labels(test_thresh)
 
     # create our widget, passing in the viewer
-    my_widget = batch_annotator()
-    my_widget()
+    # my_widget = batch_annotator()
+    # my_widget()

--- a/src/napari_ndev/_tests/test_widget.py
+++ b/src/napari_ndev/_tests/test_widget.py
@@ -1,4 +1,3 @@
-import napari
 import numpy as np
 from aicsimageio import AICSImage
 
@@ -10,7 +9,7 @@ from napari_ndev import batch_annotator  # , batch_predict, batch_training
 def test_batch_annotator(make_napari_viewer, capsys):
     # make viewer and add an image layer using our fixture
     viewer = make_napari_viewer()
-    viewer = napari.Viewer()
+    # viewer = napari.Viewer()
     test_image = np.random.random((3, 2, 4, 100, 100))
     test_aics = AICSImage(test_image)
     viewer.add_image(test_aics.data)

--- a/src/napari_ndev/_tests/test_widget.py
+++ b/src/napari_ndev/_tests/test_widget.py
@@ -1,6 +1,7 @@
 import numpy as np
+from aicsimageio import AICSImage
 
-from napari_ndev import batch_annotator  # , batch_predict, batch_training
+# from napari_ndev import batch_annotator  # , batch_predict, batch_training
 
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object
@@ -8,20 +9,15 @@ from napari_ndev import batch_annotator  # , batch_predict, batch_training
 def test_batch_annotator(make_napari_viewer, capsys):
     # make viewer and add an image layer using our fixture
     viewer = make_napari_viewer()
-    test_image = np.random.random((100, 100))
-    viewer.add_image(test_image)
+    test_image = np.random.random((3, 2, 4, 100, 100))
+    test_aics = AICSImage(test_image)
+    viewer.add_image(test_aics.data)
     test_thresh = test_image > 1
     viewer.add_labels(test_thresh)
 
     # create our widget, passing in the viewer
-    my_widget = batch_annotator()
-    my_widget()
-    # call our widget method
-    # my_widget._on_click()
-
-    # read captured output and check that it's as we expected
-    # captured = capsys.readouterr()
-    # assert captured.out == "napari has 1 layers\n"
+    # my_widget = batch_annotator()
+    # my_widget()
 
 
 # def test_batch_training(make_napari_viewer, capsys):

--- a/src/napari_ndev/_tests/test_widget.py
+++ b/src/napari_ndev/_tests/test_widget.py
@@ -1,3 +1,4 @@
+import napari
 import numpy as np
 from aicsimageio import AICSImage
 
@@ -9,50 +10,13 @@ from aicsimageio import AICSImage
 def test_batch_annotator(make_napari_viewer, capsys):
     # make viewer and add an image layer using our fixture
     viewer = make_napari_viewer()
+    viewer = napari.Viewer()
     test_image = np.random.random((3, 2, 4, 100, 100))
     test_aics = AICSImage(test_image)
     viewer.add_image(test_aics.data)
-    test_thresh = test_image > 1
+    test_thresh = test_image > 0.5
     viewer.add_labels(test_thresh)
 
     # create our widget, passing in the viewer
     # my_widget = batch_annotator()
     # my_widget()
-
-
-# def test_batch_training(make_napari_viewer, capsys):
-#     # make viewer and add an image layer using our fixture
-#     viewer = make_napari_viewer()
-#     test_image = np.random.random((100, 100))
-#     viewer.add_image(test_image)
-#     test_thresh = test_image > 1
-#     viewer.add_labels(test_thresh)
-
-#     # create our widget, passing in the viewer
-#     my_widget = batch_training()
-#     my_widget()
-#     # call our widget method
-#     # my_widget._on_click()
-
-#     # read captured output and check that it's as we expected
-#     # captured = capsys.readouterr()
-#     # assert captured.out == "napari has 1 layers\n"
-
-
-# def test_batch_predict(make_napari_viewer, capsys):
-#     # make viewer and add an image layer using our fixture
-#     viewer = make_napari_viewer()
-#     test_image = np.random.random((100, 100))
-#     viewer.add_image(test_image)
-#     test_thresh = test_image > 1
-#     viewer.add_labels(test_thresh)
-
-#     # create our widget, passing in the viewer
-#     my_widget = batch_predict()
-#     my_widget()
-#     # call our widget method
-#     # my_widget._on_click()
-
-#     # read captured output and check that it's as we expected
-#     # captured = capsys.readouterr()
-#     # assert captured.out == "napari has 1 layers\n"

--- a/src/napari_ndev/_tests/test_widget.py
+++ b/src/napari_ndev/_tests/test_widget.py
@@ -2,7 +2,7 @@ import napari
 import numpy as np
 from aicsimageio import AICSImage
 
-# from napari_ndev import batch_annotator  # , batch_predict, batch_training
+from napari_ndev import batch_annotator  # , batch_predict, batch_training
 
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object
@@ -18,5 +18,5 @@ def test_batch_annotator(make_napari_viewer, capsys):
     viewer.add_labels(test_thresh)
 
     # create our widget, passing in the viewer
-    # my_widget = batch_annotator()
-    # my_widget()
+    my_widget = batch_annotator()
+    my_widget()

--- a/src/napari_ndev/napari.yaml
+++ b/src/napari_ndev/napari.yaml
@@ -5,6 +5,9 @@ contributions:
     - id: napari-ndev.make_batch_annotator
       python_name: napari_ndev._widget:batch_annotator
       title: Make Batch Annotator Widget
+    - id: napari-ndev.make_batch_workflow
+      python_name: napari_ndev._widget:batch_workflow
+      title: Make Batch Workflow Widget
     - id: napari-ndev.make_batch_training
       python_name: napari_ndev._widget:batch_training
       title: Make Batch Training Widget
@@ -15,6 +18,8 @@ contributions:
   widgets:
     - command: napari-ndev.make_batch_annotator
       display_name: Batch Annotator
+    - command: napari-ndev.make_batch_workflow
+      display_name: Batch Workflow
     - command: napari-ndev.make_batch_training
       display_name: Batch APOC Training
     - command: napari-ndev.make_batch_predict


### PR DESCRIPTION
- fix metadata acquisition, at this point expecting images for batch annotator to be opened with napari-aicsimageio
- match ome metadata between image and labels layer by switching to OmeTiffWriter and explicitly stating metadata
- remove label_dims from batch_training because dims of label and img should always match
- now properly save physical pixel sizes to metadata