### PR TITLE
Ruff linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,40 +6,21 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: ^\.napari-hub/.*
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
-    hooks:
-      - id: isort
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus, --keep-runtime-typing]
-  - repo: https://github.com/myint/autoflake
-    rev: v2.0.0
-    hooks:
-      - id: autoflake
-        args: ["--in-place", "--remove-all-unused-imports"]
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black
-  # - repo: https://github.com/PyCQA/flake8
-  #   rev: 6.0.0
-  #   hooks:
-  #     - id: flake8
-  #       additional_dependencies: [flake8-typing-imports>=1.9.0]
+
+
   - repo: https://github.com/tlambert03/napari-plugin-checks
     rev: v0.3.0
     hooks:
       - id: napari-plugin-checks
+
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: ''  # Specify a git hash or tag, e.g., 'v0.0.79'
     hooks:
       - id: ruff
-  # https://mypy.readthedocs.io/en/stable/introduction.html
-  # you may wish to add this as well!
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.910-1
-  #   hooks:
-  #     - id: mypy
+        args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,117 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/napari_ndev/_version.py"
 
-[tool.black]
+[tool.ruff]
 line-length = 79
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".mypy_cache",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "*vendored*",
+    "*_vendor*",
+]
+fix = true
 
-[tool.isort]
-profile = "black"
-line_length = 79
+
+[tool.ruff.format]
+quote-style = "single"
+
+
+[tool.ruff.lint]
+select = [
+    "E", "F", "W", #flake8
+    "UP", # pyupgrade
+    "I", # isort
+    "YTT", #flake8-2020
+    "TCH", # flake8-type-checing
+    "BLE", # flake8-blind-exception
+    "B", # flake8-bugbear
+    "A", # flake8-builtins
+    "C4", # flake8-comprehensions
+    "ISC", # flake8-implicit-str-concat
+    "G", # flake8-logging-format
+    "PIE", # flake8-pie
+    "COM", # flake8-commas
+    "SIM", # flake8-simplify
+    "INP", # flake8-no-pep420
+    "PYI", # flake8-pyi
+    "Q", # flake8-quotes
+    "RSE", # flake8-raise
+    "RET", # flake8-return
+    "TID",  # flake8-tidy-imports # replace absolutify import
+    "TRY", # tryceratops
+    "ICN", # flake8-import-conventions
+    "RUF", # ruff specyfic rules
+    "NPY201", # checks compatibility with numpy version 2.0
+    "ASYNC", # flake8-async
+    "EXE", # flake8-executable
+    "FA", # flake8-future-annotations
+    "LOG", # flake8-logging
+    "SLOT", # flake8-slots
+    "PT", # flake8-pytest-style
+    "T20", # flake8-print
+]
+ignore = [
+    "E501", "TCH001", "TCH002", "TCH003",
+    "A003", # flake8-builtins - we have class attributes violating these rule
+    "COM812", # flake8-commas - we don't like adding comma on single line of arguments
+    "COM819", # conflicts with ruff-format
+    "SIM117", # flake8-simplify - we some of merged with statements are not looking great with black, reanble after drop python 3.9
+    "RET504", # not fixed yet https://github.com/charliermarsh/ruff/issues/2950
+    "TRY003", # require implement multiple exception class
+    "RUF005", # problem with numpy compatybility, see https://github.com/charliermarsh/ruff/issues/2142#issuecomment-1451038741
+    "B028", # need to be fixed
+    "PYI015", # it produces bad looking files (@jni opinion)
+    "W191", "Q000", "Q001", "Q002", "Q003", "ISC001", # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+]
+
+
+[tool.ruff.lint.flake8-quotes]
+docstring-quotes = "double"
+inline-quotes = "single"
+multiline-quotes = "double"
+
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"
+
+
+[tool.ruff.lint.isort]
+known-first-party=['napari']
+combine-as-imports = true
+
+
+[tool.ruff.lint.flake8-import-conventions]
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+# Declare a custom alias for the `matplotlib` module.
+"dask.array" = "da"
+xarray = "xr"
+
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError()",
+    "except ImportError:",
+    "^ +\\.\\.\\.$",
+]
+
 
 [tool.pytest.ini_options]
 markers = ["notox: mark a test to be excluded from tox"]

--- a/src/napari_ndev/__init__.py
+++ b/src/napari_ndev/__init__.py
@@ -1,27 +1,26 @@
 try:
-    from ._version import version as __version__
+    from napari_ndev._version import version as __version__
 except ImportError:
-    __version__ = "unknown"
+    __version__ = 'unknown'
 
-from . import helpers
-from ._apoc_container import ApocContainer
-from ._apoc_feature_stack import ApocFeatureStack
-from ._plate_mapper import PlateMapper
-from ._utilities_container import UtilitiesContainer
-from ._workflow_container import WorkflowContainer
-from .image_overview import ImageOverview, image_overview
-from ._measure_container import MeasureContainer
-from . import measure
+from napari_ndev import helpers, measure
+from napari_ndev._apoc_container import ApocContainer
+from napari_ndev._apoc_feature_stack import ApocFeatureStack
+from napari_ndev._measure_container import MeasureContainer
+from napari_ndev._plate_mapper import PlateMapper
+from napari_ndev._utilities_container import UtilitiesContainer
+from napari_ndev._workflow_container import WorkflowContainer
+from napari_ndev.image_overview import ImageOverview, image_overview
 
 __all__ = [
-    "WorkflowContainer",
-    "UtilitiesContainer",
-    "ApocContainer",
-    "ApocFeatureStack",
-    "MeasureContainer",
-    "PlateMapper",
-    "ImageOverview",
-    "image_overview",
-    "helpers",
-    "measure",
+    'WorkflowContainer',
+    'UtilitiesContainer',
+    'ApocContainer',
+    'ApocFeatureStack',
+    'MeasureContainer',
+    'PlateMapper',
+    'ImageOverview',
+    'image_overview',
+    'helpers',
+    'measure',
 ]

--- a/src/napari_ndev/_apoc_container.py
+++ b/src/napari_ndev/_apoc_container.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 from enum import Enum
@@ -19,10 +21,10 @@ from magicgui.widgets import (
     SpinBox,
     Table,
 )
-from napari import layers
 from pyclesperanto_prototype import set_wait_for_kernel_finish
 from qtpy.QtWidgets import QTabWidget
 
+from napari import layers
 from napari_ndev import helpers
 
 if TYPE_CHECKING:
@@ -154,11 +156,10 @@ class ApocContainer(Container):
 
     def __init__(
         self,
-        viewer: "napari.viewer.Viewer" = None,
+        viewer: napari.viewer.Viewer = None,
         # viewer = napari_viewer
     ):
         super().__init__()
-        self
         self._viewer = viewer if viewer is not None else None
         self._lazy_imports()
         self._initialize_widgets()
@@ -181,88 +182,88 @@ class ApocContainer(Container):
 
     def _initialize_widgets(self):
         self._classifier_file = FileEdit(
-            label="Classifier File (.cl)",
-            mode="r",
-            tooltip="Create a .txt file and rename it to .cl ending.",
+            label='Classifier File (.cl)',
+            mode='r',
+            tooltip='Create a .txt file and rename it to .cl ending.',
         )
 
         self._continue_training = CheckBox(
-            label="Continue Training?",
+            label='Continue Training?',
             value=True,
             tooltip=(
-                "Continue training only matters if classifier already exists."
+                'Continue training only matters if classifier already exists.'
             ),
         )
 
         self._classifier_type_mapping = {
-            "PixelClassifier": self.apoc.PixelClassifier,
-            "ObjectSegmenter": self.apoc.ObjectSegmenter,
+            'PixelClassifier': self.apoc.PixelClassifier,
+            'ObjectSegmenter': self.apoc.ObjectSegmenter,
         }
 
         self._classifier_type = RadioButtons(
-            label="Classifier Type",
-            value="ObjectSegmenter",
-            choices=["ObjectSegmenter", "PixelClassifier"],
-            tooltip="Object Segmenter is used for detecting objects of one "
-            "class, including connected components. "
-            "Pixel Classifier is used to classify pixel-types.",
+            label='Classifier Type',
+            value='ObjectSegmenter',
+            choices=['ObjectSegmenter', 'PixelClassifier'],
+            tooltip='Object Segmenter is used for detecting objects of one '
+            'class, including connected components. '
+            'Pixel Classifier is used to classify pixel-types.',
         )
         self._max_depth = SpinBox(
-            label="Num. of Forests",
+            label='Num. of Forests',
             value=2,
             max=20,
             step=1,
-            tooltip="Increases training time for each forest",
+            tooltip='Increases training time for each forest',
         )
         self._num_trees = SpinBox(
-            label="Num. of Trees",
+            label='Num. of Trees',
             value=100,
             step=50,
-            tooltip="Increases computational requirements.",
+            tooltip='Increases computational requirements.',
         )
         self._positive_class_id = SpinBox(
-            label="Object Label ID",
+            label='Object Label ID',
             value=2,
             step=1,
-            tooltip="Only used with ObjectSegmenter, otherwise ignored.",
+            tooltip='Only used with ObjectSegmenter, otherwise ignored.',
         )
 
         self._PDFS = Enum(
-            "PDFS", self.apoc.PredefinedFeatureSet._member_names_
+            'PDFS', self.apoc.PredefinedFeatureSet._member_names_
         )
         self._predefined_features = ComboBox(
-            label="Features",
+            label='Features',
             choices=self._PDFS,
             nullable=True,
             value=None,
             tooltip="All featuresets except 'custom' are premade",
         )
         self._feature_string = LineEdit(
-            label="Feature String",
+            label='Feature String',
             tooltip=(
-                "A string in the form of " "'filter1=radius1 filter2=radius2'."
+                'A string in the form of ' "'filter1=radius1 filter2=radius2'."
             ),
         )
 
     def _initialize_batch_container(self):
-        self._image_directory = FileEdit(label="Image Directory", mode="d")
-        self._label_directory = FileEdit(label="Label Directory", mode="d")
-        self._output_directory = FileEdit(label="Output Directory", mode="d")
+        self._image_directory = FileEdit(label='Image Directory', mode='d')
+        self._label_directory = FileEdit(label='Label Directory', mode='d')
+        self._output_directory = FileEdit(label='Output Directory', mode='d')
 
         self._image_channels = Select(
-            label="Image Channels",
+            label='Image Channels',
             choices=[],
             tooltip=(
-                "Channel order should be same for training and prediction."
+                'Channel order should be same for training and prediction.'
             ),
         )
-        self._channel_order_label = Label(value="Select an Image Channel!")
+        self._channel_order_label = Label(value='Select an Image Channel!')
 
-        self._batch_train_button = PushButton(label="Train")
-        self._batch_predict_button = PushButton(label="Predict")
+        self._batch_train_button = PushButton(label='Train')
+        self._batch_predict_button = PushButton(label='Predict')
 
         self._batch_train_container = Container(
-            layout="horizontal",
+            layout='horizontal',
             # label="Train Classifier on Image-Label Pairs",
         )
         self._batch_train_container.extend(
@@ -270,16 +271,16 @@ class ApocContainer(Container):
         )
 
         self._batch_predict_container = Container(
-            layout="horizontal",
+            layout='horizontal',
             # label="Predict Labels with Classifier on Images"
         )
         self._batch_predict_container.extend(
             [self._output_directory, self._batch_predict_button]
         )
 
-        self._progress_bar = ProgressBar(label="Progress:")
+        self._progress_bar = ProgressBar(label='Progress:')
 
-        self._batch_container = Container(layout="vertical")
+        self._batch_container = Container(layout='vertical')
         self._batch_container.extend(
             [
                 self._image_directory,
@@ -294,21 +295,21 @@ class ApocContainer(Container):
     def _initialize_viewer_container(self):
         self._image_layers = Select(
             choices=self._filter_layers(layers.Image),
-            label="Image Layers",
+            label='Image Layers',
         )
         self._label_layer = ComboBox(
             choices=self._filter_layers(layers.Labels),
-            label="Label Layer",
+            label='Label Layer',
         )
         self._train_image_button = PushButton(
-            label="Train classifier on selected layers using label"
+            label='Train classifier on selected layers using label'
         )
         self._predict_image_layer = PushButton(
-            label="Predict using classifier on selected layers"
+            label='Predict using classifier on selected layers'
         )
         self._single_result_label = Label()
 
-        self._viewer_container = Container(layout="vertical")
+        self._viewer_container = Container(layout='vertical')
         self._viewer_container.extend(
             [
                 self._image_layers,
@@ -340,9 +341,9 @@ class ApocContainer(Container):
         )
 
         tabs = QTabWidget()
-        tabs.addTab(self._batch_container.native, "Batch")
-        tabs.addTab(self._viewer_container.native, "Viewer")
-        tabs.addTab(self._custom_apoc_container.native, "Custom Feature Set")
+        tabs.addTab(self._batch_container.native, 'Batch')
+        tabs.addTab(self._viewer_container.native, 'Viewer')
+        tabs.addTab(self._custom_apoc_container.native, 'Custom Feature Set')
         self.native.layout().addWidget(tabs)
 
     def _connect_events(self):
@@ -381,7 +382,7 @@ class ApocContainer(Container):
         self._image_channels.choices = helpers.get_channel_names(img)
 
     def _update_channel_order(self):
-        self._channel_order_label.value = "Selected Channel Order: " + str(
+        self._channel_order_label.value = 'Selected Channel Order: ' + str(
             self._image_channels.value
         )
 
@@ -394,17 +395,17 @@ class ApocContainer(Container):
 
     def _process_classifier_metadata(self, content):
         self._classifier_type.value = self._set_value_from_pattern(
-            r"classifier_class_name\s*=\s*([^\n]+)", content
+            r'classifier_class_name\s*=\s*([^\n]+)', content
         )
         self._max_depth.value = self._set_value_from_pattern(
-            r"max_depth\s*=\s*(\d+)", content
+            r'max_depth\s*=\s*(\d+)', content
         )
         self._num_trees.value = self._set_value_from_pattern(
-            r"num_trees\s*=\s*(\d+)", content
+            r'num_trees\s*=\s*(\d+)', content
         )
         self._positive_class_id.value = (
             self._set_value_from_pattern(
-                r"positive_class_identifier\s*=\s*(\d+)", content
+                r'positive_class_identifier\s*=\s*(\d+)', content
             )
             or 2
         )
@@ -434,14 +435,14 @@ class ApocContainer(Container):
     def _classifier_statistics_table(self, custom_classifier):
         table, _ = custom_classifier.statistics()
 
-        trans_table = {"filter_name": [], "radius": []}
+        trans_table = {'filter_name': [], 'radius': []}
 
-        for value in table.keys():
+        for value in table:
             filter_name, radius = (
-                value.split("=") if "=" in value else (value, 0)
+                value.split('=') if '=' in value else (value, 0)
             )
-            trans_table["filter_name"].append(filter_name)
-            trans_table["radius"].append(int(radius))
+            trans_table['filter_name'].append(filter_name)
+            trans_table['radius'].append(int(radius))
 
         for i in range(len(next(iter(table.values())))):
             trans_table[str(i)] = [round(table[key][i], 2) for key in table]
@@ -455,7 +456,7 @@ class ApocContainer(Container):
 
     def _get_feature_set(self):
         if self._predefined_features.value.value == 1:
-            feature_set = ""
+            feature_set = ''
         else:
             feature_set = self.apoc.PredefinedFeatureSet[
                 self._predefined_features.value.name
@@ -467,29 +468,30 @@ class ApocContainer(Container):
         return feature_set
 
     def _get_training_classifier_instance(self):
-        if self._classifier_type.value == "PixelClassifier":
+        if self._classifier_type.value == 'PixelClassifier':
             return self.apoc.PixelClassifier(
                 opencl_filename=self._classifier_file.value,
                 max_depth=self._max_depth.value,
                 num_ensembles=self._num_trees.value,
             )
 
-        if self._classifier_type.value == "ObjectSegmenter":
+        if self._classifier_type.value == 'ObjectSegmenter':
             return self.apoc.ObjectSegmenter(
                 opencl_filename=self._classifier_file.value,
                 positive_class_identifier=self._positive_class_id.value,
                 max_depth=self._max_depth.value,
                 num_ensembles=self._num_trees.value,
             )
+        return None
 
     ##############################
     # Training and Prediction
     ##############################
     def _get_channel_image(self, img, channel_index_list):
-        if "S" in img.dims.order:
-            channel_img = img.get_image_data("TSZYX", S=channel_index_list)
+        if 'S' in img.dims.order:
+            channel_img = img.get_image_data('TSZYX', S=channel_index_list)
         else:
-            channel_img = img.get_image_data("TCZYX", C=channel_index_list)
+            channel_img = img.get_image_data('TCZYX', C=channel_index_list)
         return channel_img
 
     def batch_train(self):
@@ -503,23 +505,28 @@ class ApocContainer(Container):
         )
         # missing_files = check_for_missing_files(image_files, label_directory)
 
-        log_loc = self._classifier_file.value.with_suffix(".log.txt")
+        log_loc = self._classifier_file.value.with_suffix('.log.txt')
         logger, handler = helpers.setup_logger(log_loc)
 
         logger.info(
-            f"""
-        Classifier: {self._classifier_file.value}
-        Channels: {self._image_channels.value}
-        Num. Files: {len(image_files)}
-        Image Directory: {image_directory}
-        Label Directory: {label_directory}
         """
-        )
+        Classifier: %s
+        Channels: %s
+        Num. Files: %d
+        Image Directory: %s
+        Label Directory: %s
+        """,
+        self._classifier_file.value,
+        self._image_channels.value,
+        len(image_files),
+        image_directory,
+        label_directory
+    )
 
         # https://github.com/clEsperanto/pyclesperanto_prototype/issues/163
         set_wait_for_kernel_finish(True)
 
-        self._progress_bar.label = f"Training on {len(image_files)} Images"
+        self._progress_bar.label = f'Training on %s {len(image_files)} Images'
         self._progress_bar.value = 0
         self._progress_bar.max = len(image_files)
 
@@ -542,17 +549,17 @@ class ApocContainer(Container):
         # same workflow.
         for idx, image_file in enumerate(image_files):
             if not (label_directory / image_file.name).exists():
-                logger.error(f"Label file missing for {image_file.name}")
+                logger.error('Label file missing for %s', image_file.name)
                 self._progress_bar.value = idx + 1
                 continue
 
-            logger.info(f"Training Image {idx+1}: {image_file.name}")
+            logger.info('Training Image %d: %s', idx+1, image_file.name)
 
             img = AICSImage(image_directory / image_file.name)
             channel_img = self._get_channel_image(img, channel_index_list)
 
             lbl = AICSImage(label_directory / image_file.name)
-            label = lbl.get_image_data("TCZYX", C=0)
+            label = lbl.get_image_data('TCZYX', C=0)
 
             # <- this is where setting up dask processing would be useful
 
@@ -564,13 +571,13 @@ class ApocContainer(Container):
                     continue_training=True,
                 )
                 self._progress_bar.value = idx + 1
-            except Exception as e:
-                logger.error(f"Error training {image_file}: {e}")
+            except Exception:
+                logger.exception('Error training %s', image_file)
                 self._progress_bar.value = idx + 1
                 continue
 
         self._classifier_statistics_table(custom_classifier)
-        self._progress_bar.label = f"Trained on {len(image_files)} Images"
+        self._progress_bar.label = f'Trained on {len(image_files)} Images'
         logger.removeHandler(handler)
 
     def _get_prediction_classifier_instance(self):
@@ -581,33 +588,38 @@ class ApocContainer(Container):
             return classifier_class(
                 opencl_filename=self._classifier_file.value
             )
-        else:
-            return None
+        return None
 
     def batch_predict(self):
         from aicsimageio import AICSImage
         from aicsimageio.writers import OmeTiffWriter
 
         image_directory, image_files = helpers.get_directory_and_files(
-            dir=self._image_directory.value,
+            dir_path=self._image_directory.value,
         )
 
-        log_loc = self._output_directory.value / "log.txt"
+        log_loc = self._output_directory.value / 'log.txt'
         logger, handler = helpers.setup_logger(log_loc)
 
         logger.info(
-            f"""
-        Classifier: {self._classifier_file.value}
-        Channels: {self._image_channels.value}
-        Num. Files: {len(image_files)}
-        Image Directory: {image_directory}
-        Output Directory: {self._output_directory.value}"""
-        )
+        """
+        Classifier: %s
+        Channels: %s
+        Num. Files: %d
+        Image Directory: %s
+        Output Directory: %s
+        """,
+        self._classifier_file.value,
+        self._image_channels.value,
+        len(image_files),
+        image_directory,
+        self._output_directory.value
+    )
 
         # https://github.com/clEsperanto/pyclesperanto_prototype/issues/163
         set_wait_for_kernel_finish(True)
 
-        self._progress_bar.label = f"Predicting {len(image_files)} Images"
+        self._progress_bar.label = f'Predicting {len(image_files)} Images'
         self._progress_bar.value = 0
         self._progress_bar.max = len(image_files)
 
@@ -619,7 +631,7 @@ class ApocContainer(Container):
         ]
 
         for idx, file in enumerate(image_files):
-            logger.info(f"Predicting Image {idx+1}: {file.name}")
+            logger.info('Predicting Image %d: %s', idx+1, file.name)
 
             img = AICSImage(file)
             channel_img = self._get_channel_image(img, channel_index_list)
@@ -631,8 +643,8 @@ class ApocContainer(Container):
                 result = custom_classifier.predict(
                     image=np.squeeze(channel_img)
                 )
-            except Exception as e:
-                logger.error(f"Error predicting {file}: {e}")
+            except Exception:
+                logger.exception('Error predicting %s', file)
                 self._progress_bar.value = idx + 1
                 continue
 
@@ -644,23 +656,23 @@ class ApocContainer(Container):
 
             OmeTiffWriter.save(
                 data=save_data,
-                uri=self._output_directory.value / (file.stem + ".tiff"),
+                uri=self._output_directory.value / (file.stem + '.tiff'),
                 dim_order=squeezed_dim_order,
-                channel_names=["Labels"],
+                channel_names=['Labels'],
                 physical_pixel_sizes=img.physical_pixel_sizes,
             )
             del result
 
             self._progress_bar.value = idx + 1
 
-        self._progress_bar.label = f"Predicted {len(image_files)} Images"
+        self._progress_bar.label = f'Predicted {len(image_files)} Images'
         logger.removeHandler(handler)
 
     def image_train(self):
         image_names = [image.name for image in self._image_layers.value]
         label_name = self._label_layer.value.name
         self._single_result_label.value = (
-            f"Training on {image_names} using {label_name}"
+            f'Training on {image_names} using {label_name}'
         )
 
         image_list = [image.data for image in self._image_layers.value]
@@ -684,7 +696,7 @@ class ApocContainer(Container):
         )
 
         self._single_result_label.value = (
-            f"Trained on {image_names} using {label_name}"
+            f'Trained on {image_names} using {label_name}'
         )
 
     def image_predict(self):
@@ -693,7 +705,7 @@ class ApocContainer(Container):
         )  # https://github.com/clEsperanto/pyclesperanto_prototype/issues/163
 
         image_names = [image.name for image in self._image_layers.value]
-        self._single_result_label.value = f"Predicting {image_names}"
+        self._single_result_label.value = f'Predicting {image_names}'
         image_list = [image.data for image in self._image_layers.value]
         image_stack = np.stack(image_list, axis=0)
         scale = self._image_layers.value[0].scale
@@ -711,7 +723,7 @@ class ApocContainer(Container):
 
         self._viewer.add_labels(result, scale=scale)
 
-        self._single_result_label.value = f"Predicted {image_names}"
+        self._single_result_label.value = f'Predicted {image_names}'
 
         return result
 

--- a/src/napari_ndev/_apoc_feature_stack.py
+++ b/src/napari_ndev/_apoc_feature_stack.py
@@ -9,6 +9,7 @@ from magicgui.widgets import (
     PushButton,
     TextEdit,
 )
+
 from napari import layers
 
 if TYPE_CHECKING:
@@ -18,32 +19,31 @@ if TYPE_CHECKING:
 class ApocFeatureStack(Container):
     def __init__(
         self,
-        viewer: "napari.viewer.Viewer" = None,
+        viewer: 'napari.viewer.Viewer' = None,
     ):
         super().__init__()
-        self
         self._viewer = viewer if viewer is not None else None
 
-        self._original = CheckBox(label="Keep Original Image")
-        self._gaussian_blur = LineEdit(label="Gaussian Blur")
-        self._DoG = LineEdit(label="Difference of Gauss.")
-        self._LoG = LineEdit(label="Laplacian of Gauss.")
-        self._SoG = LineEdit(label="Sobel of Gauss.")
-        self._sHoG = LineEdit(label="Small Hessian of Gauss.")
-        self._lHoG = LineEdit(label="Large Hessian of Gauss.")
-        self._median = LineEdit(label="Median")
-        self._tophat = LineEdit(label="Top Hat")
+        self._original = CheckBox(label='Keep Original Image')
+        self._gaussian_blur = LineEdit(label='Gaussian Blur')
+        self._DoG = LineEdit(label='Difference of Gauss.')
+        self._LoG = LineEdit(label='Laplacian of Gauss.')
+        self._SoG = LineEdit(label='Sobel of Gauss.')
+        self._sHoG = LineEdit(label='Small Hessian of Gauss.')
+        self._lHoG = LineEdit(label='Large Hessian of Gauss.')
+        self._median = LineEdit(label='Median')
+        self._tophat = LineEdit(label='Top Hat')
 
         self._generate_string_button = PushButton(
-            label="Generate Feature String"
+            label='Generate Feature String'
         )
-        self._feature_string = TextEdit(label="Custom Feature String")
+        self._feature_string = TextEdit(label='Custom Feature String')
 
         self._image_layer = ComboBox(
-            choices=self._filter_layers(layers.Image), label="Image Layer"
+            choices=self._filter_layers(layers.Image), label='Image Layer'
         )
-        self._apply_button = PushButton(label="Apply to selected image")
-        self._progress_bar = ProgressBar(label="Progress: ")
+        self._apply_button = PushButton(label='Apply to selected image')
+        self._progress_bar = ProgressBar(label='Progress: ')
 
         self.extend(
             [
@@ -89,44 +89,44 @@ class ApocFeatureStack(Container):
         def process_feature(prefix, input_str):
             return [
                 prefix + num.strip()
-                for num in input_str.split(",")
+                for num in input_str.split(',')
                 if num.strip()
             ]
 
         feature_list = []
         if self._original.value:
-            feature_list.append("original")
+            feature_list.append('original')
         feature_list.extend(
-            process_feature("gaussian_blur=", self._gaussian_blur.value)
+            process_feature('gaussian_blur=', self._gaussian_blur.value)
         )
         feature_list.extend(
-            process_feature("difference_of_gaussian=", self._DoG.value)
+            process_feature('difference_of_gaussian=', self._DoG.value)
         )
         feature_list.extend(
-            process_feature("laplace_box_of_gaussian_blur=", self._LoG.value)
+            process_feature('laplace_box_of_gaussian_blur=', self._LoG.value)
         )
         feature_list.extend(
-            process_feature("sobel_of_gaussian_blur=", self._SoG.value)
+            process_feature('sobel_of_gaussian_blur=', self._SoG.value)
         )
         feature_list.extend(
             process_feature(
-                "small_hessian_eigenvalue_of_gaussian_blur=", self._sHoG.value
+                'small_hessian_eigenvalue_of_gaussian_blur=', self._sHoG.value
             )
         )
         feature_list.extend(
             process_feature(
-                "large_hessian_eigenvalue_of_gaussian_blur=",
+                'large_hessian_eigenvalue_of_gaussian_blur=',
                 self._lHoG.value,
             )
         )
         feature_list.extend(
-            process_feature("median_sphere=", self._median.value)
+            process_feature('median_sphere=', self._median.value)
         )
         feature_list.extend(
-            process_feature("top_hat_sphere=", self._tophat.value)
+            process_feature('top_hat_sphere=', self._tophat.value)
         )
 
-        self._feature_string.value = " ".join(feature_list)
+        self._feature_string.value = ' '.join(feature_list)
 
     def layer_to_feature_stack(self):
         from apoc import generate_feature_stack

--- a/src/napari_ndev/_measure_container.py
+++ b/src/napari_ndev/_measure_container.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -8,7 +10,6 @@ from magicgui.widgets import (
     ComboBox,
     Container,
     FileEdit,
-
     LineEdit,
     ProgressBar,
     PushButton,
@@ -23,8 +24,9 @@ from napari_ndev import helpers
 if TYPE_CHECKING:
     import pathlib
 
-    import napari
     from bioio import BioImage
+
+    import napari
 
 
 class MeasureContainer(Container):
@@ -32,10 +34,9 @@ class MeasureContainer(Container):
     intensity images, which can be microscopy data or other labels.
     """
 
-
     def __init__(
         self,
-        viewer: "napari.viewer.Viewer" = None,
+        viewer: napari.viewer.Viewer = None,
     ):
         super().__init__()
 
@@ -44,7 +45,7 @@ class MeasureContainer(Container):
         self._intensity_choices = []
         self._p_sizes = None
         self._squeezed_dims = None
-        self._prop = type("", (), {})()
+        self._prop = type('', (), {})()
 
         self._init_widgets()
         self._init_regionprops_container()
@@ -55,57 +56,57 @@ class MeasureContainer(Container):
         self._connect_events()
 
     def _init_widgets(self):
-        self._label_directory = FileEdit(label="Label directory", mode="d")
+        self._label_directory = FileEdit(label='Label directory', mode='d')
         self._image_directory = FileEdit(
-            label="Image directory", mode="d", nullable=True
+            label='Image directory', mode='d', nullable=True
         )
         self._region_directory = FileEdit(
-            label="Region directory", mode="d", nullable=True
+            label='Region directory', mode='d', nullable=True
         )
-        self._output_directory = FileEdit(label="Output directory", mode="d")
+        self._output_directory = FileEdit(label='Output directory', mode='d')
 
         self._label_image = ComboBox(
-            label="Label image",
+            label='Label image',
             choices=self._label_choices,
             nullable=False,
-            tooltip="Select label image to measure",
+            tooltip='Select label image to measure',
         )
         self._intensity_images = Select(
-            label="Intensity images",
+            label='Intensity images',
             choices=self._intensity_choices,
             allow_multiple=True,
             nullable=True,
-            tooltip="Select intensity images to compare against labels",
+            tooltip='Select intensity images to compare against labels',
         )
         self._scale_tuple = TupleEdit(
             value=(0.0000, 1.0000, 1.0000),
-            label="Physical Pixel Sizes, ZYX",
-            tooltip="Pixel size, usually in μm/px",
-            options={"step": 0.0001},
+            label='Physical Pixel Sizes, ZYX',
+            tooltip='Pixel size, usually in μm/px',
+            options={'step': 0.0001},
         )
-        self._measure_button = PushButton(label="Measure")
+        self._measure_button = PushButton(label='Measure')
 
-        self._progress_bar = ProgressBar(label="Progress:")
+        self._progress_bar = ProgressBar(label='Progress:')
 
     def _init_regionprops_container(self):
-        self._props_container = Container(layout="vertical")
+        self._props_container = Container(layout='vertical')
 
         self._sk_props = [
-            "area",
-            "area_convex",
-            "bbox",
-            "centroid",
-            "eccentricity",
-            "extent",
-            "feret_diameter_max",
-            "intensity_max",
-            "intensity_mean",
-            "intensity_min",
-            "intensity_std",
-            "num_pixels",
-            "orientation",
-            "perimeter",
-            "solidity",
+            'area',
+            'area_convex',
+            'bbox',
+            'centroid',
+            'eccentricity',
+            'extent',
+            'feret_diameter_max',
+            'intensity_max',
+            'intensity_mean',
+            'intensity_min',
+            'intensity_std',
+            'num_pixels',
+            'orientation',
+            'perimeter',
+            'solidity',
         ]
 
         for feature in self._sk_props:
@@ -115,38 +116,38 @@ class MeasureContainer(Container):
         self._prop.area.value = True
 
     def _init_id_regex_container(self):
-        self._id_regex_container = Container(layout="vertical")
+        self._id_regex_container = Container(layout='vertical')
         self._example_id_string = LineEdit(
-            label="Example ID String",
+            label='Example ID String',
             value=None,
             nullable=True,
         )
         self._id_regex_dict = TextEdit(
-            label="ID Regex Dict",
-            value="{\n\n}",
+            label='ID Regex Dict',
+            value='{\n\n}',
         )
         self._id_regex_container.extend(
             [self._example_id_string, self._id_regex_dict]
         )
 
     def _init_tx_map_container(self):
-        self._tx_map_container = Container(layout="vertical")
+        self._tx_map_container = Container(layout='vertical')
         self._tx_id = LineEdit(
-            label="Treatment ID",
+            label='Treatment ID',
             value=None,
             nullable=True,
-            tooltip="Usually, the treatment ID is the well ID or a unique identifier for each sample"
+            tooltip='Usually, the treatment ID is the well ID or a unique identifier for each sample'
             "The treatment dict will be looked up against whatever this value is. If it is 'file', then will match against the filename",
         )
         self._tx_n_well = ComboBox(
-            label="Number of Wells",
+            label='Number of Wells',
             value=None,
             choices=[6, 12, 24, 48, 96, 384],
             nullable=True,
-            tooltip="By default, treatments must be verbosely defined for each condition and sample id"
-            "If you have a known plate map, then selecting wells will allow a sparse treatment map to be passed to PlateMapper",
+            tooltip='By default, treatments must be verbosely defined for each condition and sample id'
+            'If you have a known plate map, then selecting wells will allow a sparse treatment map to be passed to PlateMapper',
         )
-        self._tx_dict = TextEdit(label="Treatment Dict", value="{\n\n}")
+        self._tx_dict = TextEdit(label='Treatment Dict', value='{\n\n}')
         # TODO: Add example treatment regex result widget when example id string or id regex dict is changed
 
         self._tx_map_container.extend(
@@ -154,16 +155,16 @@ class MeasureContainer(Container):
         )
 
     def _init_grouping_container(self):
-        self._grouping_container = Container(layout="vertical")
+        self._grouping_container = Container(layout='vertical')
         self._create_grouped = CheckBox(
-            label="Create Grouped Data",
+            label='Create Grouped Data',
             value=False,
-            tooltip="If checked, will create a grouped data frame with the same properties as the original data frame",
+            tooltip='If checked, will create a grouped data frame with the same properties as the original data frame',
         )
         self._group_by_sample_id = CheckBox(
-            label="Group by Sample ID",
+            label='Group by Sample ID',
             value=True,
-            tooltip="If checked, will group the data by the id_string, which is usually the filename and scene",
+            tooltip='If checked, will group the data by the id_string, which is usually the filename and scene',
         )
 
         self._grouping_container.extend(
@@ -186,10 +187,10 @@ class MeasureContainer(Container):
         )
 
         tabs = QTabWidget()
-        tabs.addTab(self._props_container.native, "Region Props")
-        tabs.addTab(self._id_regex_container.native, "ID Regex")
-        tabs.addTab(self._tx_map_container.native, "Tx Map")
-        tabs.addTab(self._grouping_container.native, "Grouping")
+        tabs.addTab(self._props_container.native, 'Region Props')
+        tabs.addTab(self._id_regex_container.native, 'ID Regex')
+        tabs.addTab(self._tx_map_container.native, 'Tx Map')
+        tabs.addTab(self._grouping_container.native, 'Grouping')
         self.native.layout().addWidget(tabs)
 
     def _connect_events(self):
@@ -199,8 +200,8 @@ class MeasureContainer(Container):
         self._measure_button.clicked.connect(self.batch_measure)
 
     def _get_0th_img_from_dir(
-        self, directory: str = None
-    ) -> Tuple["BioImage", "pathlib.Path"]:
+        self, directory: str | None = None
+    ) -> tuple[BioImage, pathlib.Path]:
         from bioio import BioImage
 
         _, files = helpers.get_directory_and_files(directory)
@@ -217,7 +218,7 @@ class MeasureContainer(Container):
     def _update_choices(self, directory, prefix, update_label=False):
         img, _ = self._get_0th_img_from_dir(directory)
         img_channels = helpers.get_channel_names(img)
-        img_channels = [f"{prefix}: {channel}" for channel in img_channels]
+        img_channels = [f'{prefix}: {channel}' for channel in img_channels]
 
         if update_label:
             self._update_dim_and_scales(img)
@@ -228,30 +229,29 @@ class MeasureContainer(Container):
         self._intensity_images.choices = self._intensity_choices
 
     def _update_image_choices(self):
-        self._update_choices(self._image_directory.value, "Intensity")
+        self._update_choices(self._image_directory.value, 'Intensity')
 
     def _update_label_choices(self):
         self._update_choices(
-            self._label_directory.value, "Labels", update_label=True
+            self._label_directory.value, 'Labels', update_label=True
         )
-        img, id = self._get_0th_img_from_dir(self._label_directory.value)
-        id_string = helpers.create_id_string(img, id.stem)
+        img, file_id = self._get_0th_img_from_dir(self._label_directory.value)
+        id_string = helpers.create_id_string(img, file_id.stem)
         self._example_id_string.value = id_string
 
     def _update_region_choices(self):
-        self._update_choices(self._region_directory.value, "Region")
+        self._update_choices(self._region_directory.value, 'Region')
 
     def _safe_dict_eval(self, dict_string, dict_name=None):
         if dict_string is None:
             return None
 
         stripped_string = dict_string.strip()
-        if stripped_string == "{}" or not stripped_string:
+        if stripped_string == '{}' or not stripped_string:
             return None
         try:
             return ast.literal_eval(stripped_string)
-        except Exception as e:
-            print(f"{e}: Invalid dict: {dict_name}")
+        except (ValueError, SyntaxError):
             return None
 
     def batch_measure(self) -> pd.DataFrame:
@@ -270,39 +270,52 @@ class MeasureContainer(Container):
         region_dir, region_files = helpers.get_directory_and_files(
             self._region_directory.value
         )
-        # check if the label files are the same as the image files
-        if self._image_directory.value is not None:
-            if len(label_files) != len(image_files):
-                raise ValueError(
-                    "Number of label files and image files do not match"
-                )
-        if self._region_directory.value is not None:
-            if len(label_files) != len(region_files):
-                raise ValueError(
-                    "Number of label files and region files do not match"
-                )
 
-        log_loc = self._output_directory.value / ".log.txt"
+        # check if the label files are the same as the image files
+        # if self._image_directory.value is not None:
+        #     if len(label_files) != len(image_files):
+        #         raise ValueError(
+        #             'Number of label files and image files do not match'
+        #         )
+        # if self._region_directory.value is not None:
+        #     if len(label_files) != len(region_files):
+        #         raise ValueError(
+        #             'Number of label files and region files do not match'
+        #         )
+
+        log_loc = self._output_directory.value / '.log.txt'
         logger, handler = helpers.setup_logger(log_loc)
 
         logger.info(
-            f"""
-        Label Image: {self._label_image.value}
-        Intensity Channels: {self._intensity_images.value}
-        Num. Files: {len(label_files)}
-        Label Directory: {label_dir}
-        Image Directory: {image_dir}
-        Region Directory: {region_dir}
-        Output Directory: {self._output_directory.value}
-        ID Example: {self._example_id_string.value}
-        ID Regex Dict: {self._id_regex_dict.value}
-        Tx ID: {self._tx_id.value}
-        Tx N Well: {self._tx_n_well.value}
-        Tx Dict: {self._tx_dict.value}
-        """
+            """
+            Label Image: %s
+            Intensity Channels: %s
+            Num. Files: %d
+            Label Directory: %s
+            Image Directory: %s
+            Region Directory: %s
+            Output Directory: %s
+            ID Example: %s
+            ID Regex Dict: %s
+            Tx ID: %s
+            Tx N Well: %s
+            Tx Dict: %s
+            """,
+            self._label_image.value,
+            self._intensity_images.value,
+            len(label_files),
+            label_dir,
+            image_dir,
+            region_dir,
+            self._output_directory.value,
+            self._example_id_string.value,
+            self._id_regex_dict.value,
+            self._tx_id.value,
+            self._tx_n_well.value,
+            self._tx_dict.value
         )
 
-        self._progress_bar.label = f"Measuring {len(label_files)} Images"
+        self._progress_bar.label = f'Measuring {len(label_files)} Images'
         self._progress_bar.value = 0
         self._progress_bar.max = len(label_files)
         # get the relevant spacing for regionprops, depending on length
@@ -314,14 +327,14 @@ class MeasureContainer(Container):
         ]
 
         id_regex_dict = self._safe_dict_eval(
-            self._id_regex_dict.value, "ID Regex Dict"
+            self._id_regex_dict.value, 'ID Regex Dict'
         )
-        tx_dict = self._safe_dict_eval(self._tx_dict.value, "Tx Dict")
+        tx_dict = self._safe_dict_eval(self._tx_dict.value, 'Tx Dict')
         measure_props_concat = []
 
         for idx, file in enumerate(label_files):
             # TODO: Add scene processing
-            logger.info(f"Processing file {file.name}")
+            logger.info('Processing file %s', file.name)
             lbl = BioImage(label_dir / file.name)
             id_string = helpers.create_id_string(lbl, file.stem)
 
@@ -336,7 +349,7 @@ class MeasureContainer(Container):
                 image_path = image_dir / file.name
                 if not image_path.exists():
                     logger.error(
-                        f"Image file {file.name} not found in intensity directory"
+                        'Image file %s not found in intensity directory', file.name
                     )
                     self._progress_bar.value = idx + 1
                     continue
@@ -345,14 +358,14 @@ class MeasureContainer(Container):
                 region_path = region_dir / file.name
                 if not region_path.exists():
                     logger.error(
-                        f"Region file {file.name} not found in region directory"
+                        'Region file %s not found in region directory', file.name
                     )
                     self._progress_bar.value = idx + 1
                     continue
                 reg = BioImage(region_path)
 
-            for scene_idx, scene in enumerate(lbl.scenes):
-                logger.info(f"Processing scene {scene_idx}")
+            for scene_idx, _scene in enumerate(lbl.scenes):
+                logger.info('Processing scene %s', scene_idx)
                 lbl.set_scene(scene_idx)
                 label = lbl.get_image_data(self._squeezed_dims, C=lbl_C)
                 id_string = helpers.create_id_string(lbl, file.stem)
@@ -360,21 +373,21 @@ class MeasureContainer(Container):
                 # Get stack of intensity images if there are any selected
                 if self._intensity_images.value and not None:
                     for channel in self._intensity_images.value:
-                        if channel.startswith("Labels: "):
+                        if channel.startswith('Labels: '):
                             chan = channel[8:]
                             lbl_C = lbl.channel_names.index(chan)
                             lbl.set_scene(scene_idx)
                             chan_img = lbl.get_image_data(
                                 self._squeezed_dims, C=lbl_C
                             )
-                        elif channel.startswith("Intensity: "):
+                        elif channel.startswith('Intensity: '):
                             chan = channel[11:]
                             img_C = img.channel_names.index(chan)
                             img.set_scene(scene_idx)
                             chan_img = img.get_image_data(
                                 self._squeezed_dims, C=img_C
                             )
-                        elif channel.startswith("Region: "):
+                        elif channel.startswith('Region: '):
                             chan = channel[8:]
                             reg_C = reg.channel_names.index(chan)
                             img.set_scene(scene_idx)
@@ -413,26 +426,25 @@ class MeasureContainer(Container):
 
         measure_props_df = pd.concat(measure_props_concat)
         measure_props_df.to_csv(
-            self._output_directory.value / f"measure_props_{label_chan}.csv"
+            self._output_directory.value / f'measure_props_{label_chan}.csv'
         )
 
         if self._create_grouped.value:
             if self._group_by_sample_id.value:
-
                 # get count data
                 measure_props_count = (
-                    measure_props_df.groupby("id")
-                    .agg({measure_props_df.columns[0]: "count"})
+                    measure_props_df.groupby('id')
+                    .agg({measure_props_df.columns[0]: 'count'})
                     .rename(
-                        columns={measure_props_df.columns[0]: "label_count"}
+                        columns={measure_props_df.columns[0]: 'label_count'}
                     )
                     .reset_index(drop=True)
                 )
                 measure_props_grouped = (
-                    measure_props_df.groupby("id")  # sw
+                    measure_props_df.groupby('id')  # sw
                     .agg(
                         {
-                            col: ["mean", "std"]
+                            col: ['mean', 'std']
                             for col in measure_props_df.columns[1:]
                         }
                     )
@@ -440,7 +452,7 @@ class MeasureContainer(Container):
                 )  # genereates a multi-index
                 # collapse multi index and combine columns names with '_' sep
                 measure_props_grouped.columns = [
-                    f"{col[0]}_{col[1]}" if col[1] else col[0]
+                    f'{col[0]}_{col[1]}' if col[1] else col[0]
                     for col in measure_props_grouped.columns
                 ]
 
@@ -450,7 +462,7 @@ class MeasureContainer(Container):
 
             measure_props_grouped.to_csv(
                 self._output_directory.value
-                / f"measure_props_grouped_{label_chan}.csv"
+                / f'measure_props_grouped_{label_chan}.csv'
             )
         else:
             measure_props_grouped = None

--- a/src/napari_ndev/_plate_mapper.py
+++ b/src/napari_ndev/_plate_mapper.py
@@ -65,12 +65,12 @@ class PlateMapper:
         well_rows.sort()  # needed to sort the rows correctly
         well_columns = column_labels * num_rows
 
-        well_labels_dict = {"row": well_rows, "column": well_columns}
+        well_labels_dict = {'row': well_rows, 'column': well_columns}
 
         plate_map_df = pd.DataFrame(well_labels_dict)
 
-        plate_map_df["well_id"] = plate_map_df["row"] + plate_map_df[
-            "column"
+        plate_map_df['well_id'] = plate_map_df['row'] + plate_map_df[
+            'column'
         ].astype(str)
         self.plate_map = plate_map_df
         return plate_map_df
@@ -90,20 +90,20 @@ class PlateMapper:
         for treatment, conditions in treatments.items():
             for condition, wells in conditions.items():
                 for well in wells:
-                    if ":" in well:
-                        start, end = well.split(":")
+                    if ':' in well:
+                        start, end = well.split(':')
                         start_row, start_col = start[0], int(start[1:])
                         end_row, end_col = end[0], int(end[1:])
                         well_condition = (
-                            (self.plate_map["row"] >= start_row)
-                            & (self.plate_map["row"] <= end_row)
-                            & (self.plate_map["column"] >= start_col)
-                            & (self.plate_map["column"] <= end_col)
+                            (self.plate_map['row'] >= start_row)
+                            & (self.plate_map['row'] <= end_row)
+                            & (self.plate_map['column'] >= start_col)
+                            & (self.plate_map['column'] <= end_col)
                         )
                     else:
                         row, col = well[0], int(well[1:])
-                        well_condition = (self.plate_map["row"] == row) & (
-                            self.plate_map["column"] == col
+                        well_condition = (self.plate_map['row'] == row) & (
+                            self.plate_map['column'] == col
                         )
 
                     self.plate_map.loc[well_condition, treatment] = condition
@@ -123,12 +123,12 @@ class PlateMapper:
             with treatments as columns.
         """
         plate_map_pivot = self.plate_map.pivot(
-            index="row", columns="column", values=treatment
+            index='row', columns='column', values=treatment
         )
         self.plate_map_pivot = plate_map_pivot
         return plate_map_pivot
 
-    def get_styled_plate_map(self, treatment, palette="colorblind"):
+    def get_styled_plate_map(self, treatment, palette='colorblind'):
         """
         Style a plate map DataFrame with different background colors for each
         unique value.
@@ -159,14 +159,13 @@ class PlateMapper:
 
         def get_background_color(value):
             if pd.isna(value):
-                return ""
-            else:
-                return f"background-color: {color_dict[value]}"
+                return ''
+            return f'background-color: {color_dict[value]}'
 
         plate_map_styled = (
             self.plate_map_pivot.style.applymap(get_background_color)
-            .set_caption(f"{treatment} Plate Map")
-            .format(lambda x: "" if pd.isna(x) else x)
+            .set_caption(f'{treatment} Plate Map')
+            .format(lambda x: '' if pd.isna(x) else x)
         )
 
         return plate_map_styled

--- a/src/napari_ndev/_tests/test_apoc_container.py
+++ b/src/napari_ndev/_tests/test_apoc_container.py
@@ -15,8 +15,8 @@ def test_update_channel_order(make_napari_viewer):
     viewer = make_napari_viewer()
 
     wdg = ApocContainer(viewer)
-    wdg._image_channels.choices = ["C0", "C1", "C2", "C3"]
-    wdg._image_channels.value = ["C1", "C3"]
+    wdg._image_channels.choices = ['C0', 'C1', 'C2', 'C3']
+    wdg._image_channels.value = ['C1', 'C3']
     wdg._update_channel_order()
     assert (
         wdg._channel_order_label.value
@@ -27,15 +27,15 @@ def test_update_channel_order(make_napari_viewer):
 @pytest.fixture
 def dummy_classifier_file():
     with tempfile.TemporaryDirectory() as tmpdir:
-        classifier_file_path = os.path.join(tmpdir, "dummy_classifier.cl")
-        with open(classifier_file_path, "w") as f:
+        classifier_file_path = os.path.join(tmpdir, 'dummy_classifier.cl')
+        with open(classifier_file_path, 'w') as f:
             f.write(
-                "OpenCL RandomForestClassifier\n"
-                "classifier_class_name = PixelClassifier\n"
-                "num_ground_truth_dimensions = 2\n"
-                "num_classes = 3\n"
-                "max_depth = 5\n"
-                "num_trees = 100\n"
+                'OpenCL RandomForestClassifier\n'
+                'classifier_class_name = PixelClassifier\n'
+                'num_ground_truth_dimensions = 2\n'
+                'num_classes = 3\n'
+                'max_depth = 5\n'
+                'num_trees = 100\n'
                 # "positive_class_identifier = 2\n"
             )
         yield classifier_file_path
@@ -52,7 +52,7 @@ def test_update_classifier_metadata(make_napari_viewer, dummy_classifier_file):
 
     # additional widget because of calling wdg._classifier_statistics_table()
     assert len(viewer.window._dock_widgets) == 1 + num_widgets
-    assert wdg._classifier_type.value == "PixelClassifier"
+    assert wdg._classifier_type.value == 'PixelClassifier'
     # assert wdg._classifier_channels.value == "Trained on 3 Channels"
     assert wdg._max_depth.value == 5
     assert wdg._num_trees.value == 100
@@ -92,8 +92,8 @@ labels_4d = np.array(
 
 @pytest.fixture(
     params=[
-        (image_2d, shapes_2d, labels_2d, "YX"),
-        (image_4d, shapes_4d, labels_4d, "TZYX"),
+        (image_2d, shapes_2d, labels_2d, 'YX'),
+        (image_4d, shapes_4d, labels_4d, 'TZYX'),
     ]
 )
 def test_data(request: pytest.FixtureRequest):
@@ -103,9 +103,9 @@ def test_data(request: pytest.FixtureRequest):
 @pytest.fixture
 def empty_classifier_file():
     with tempfile.TemporaryDirectory() as tmpdir:
-        classifier_file_path = os.path.join(tmpdir, "empty_classifier.cl")
-        with open(classifier_file_path, "w") as f:
-            f.write("")
+        classifier_file_path = os.path.join(tmpdir, 'empty_classifier.cl')
+        with open(classifier_file_path, 'w') as f:
+            f.write('')
         yield classifier_file_path
 
 
@@ -118,9 +118,9 @@ def test_image_train(make_napari_viewer, test_data, empty_classifier_file):
 
     wdg = ApocContainer(viewer)
 
-    wdg._image_layers.value = [viewer.layers["test_image"]]
-    wdg._label_layer.value = viewer.layers["test_labels"]
-    wdg._classifier_type.value = "ObjectSegmenter"
+    wdg._image_layers.value = [viewer.layers['test_image']]
+    wdg._label_layer.value = viewer.layers['test_labels']
+    wdg._classifier_type.value = 'ObjectSegmenter'
     wdg._continue_training.value = False
     wdg._classifier_file.value = empty_classifier_file
     wdg._positive_class_id.value = 2
@@ -131,15 +131,16 @@ def test_image_train(make_napari_viewer, test_data, empty_classifier_file):
     wdg._predefined_features.value = PDFS.small_quick
 
     wdg.image_train()
-    result_classifier = open(empty_classifier_file).read()
+    with open(empty_classifier_file) as f:
+        result_classifier = f.read()
 
     assert (
         wdg._single_result_label.value
         == "Trained on ['test_image'] using test_labels"
     )
     # check classifier contents after wdg.image_train()
-    assert "ObjectSegmenter" in result_classifier
-    assert "num_trees = 50" in result_classifier
+    assert 'ObjectSegmenter' in result_classifier
+    assert 'num_trees = 50' in result_classifier
 
 
 @pytest.fixture
@@ -149,7 +150,7 @@ def trained_classifier_file(
     empty_classifier_file,
 ):
     test_image_train(make_napari_viewer, test_data, empty_classifier_file)
-    yield empty_classifier_file
+    return empty_classifier_file
 
 
 @pytest.mark.notox
@@ -160,29 +161,29 @@ def test_image_predict(make_napari_viewer, test_data, trained_classifier_file):
 
     wdg = ApocContainer(viewer)
 
-    wdg._image_layers.value = [viewer.layers["test_image"]]
+    wdg._image_layers.value = [viewer.layers['test_image']]
     wdg._classifier_file.value = trained_classifier_file
 
     result = wdg.image_predict()
 
     assert wdg._single_result_label.value == "Predicted ['test_image']"
     assert cle.pull(result).any() > 0
-    assert cle.pull(wdg._viewer.layers["result"].data).any() > 0
+    assert cle.pull(wdg._viewer.layers['result'].data).any() > 0
 
 
 @pytest.mark.notox
 # def test_batch_predict_normal_operation(make_napari_viewer, tmp_path):
 def test_batch_predict_normal_operation(tmp_path):
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Apoc/Images"
+        'src/napari_ndev/_tests/resources/Apoc/Images'
     )
-    num_files = len(list(image_directory.glob("*.tiff")))
-    output_directory = tmp_path / "output"
+    num_files = len(list(image_directory.glob('*.tiff')))
+    output_directory = tmp_path / 'output'
     output_directory.mkdir()
 
     classifier = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Apoc"
-        "/Classifiers/newlabels_pixel_classifier.cl"
+        'src/napari_ndev/_tests/resources/Apoc'
+        '/Classifiers/newlabels_pixel_classifier.cl'
     )
 
     # Create an instance of ApocContainer
@@ -191,14 +192,14 @@ def test_batch_predict_normal_operation(tmp_path):
     container._image_directory.value = image_directory
     container._output_directory.value = output_directory
     # container._image_channels.value = ["IBA1"] # images need fixed
-    container._image_channels.value = ["Labels"]
+    container._image_channels.value = ['Labels']
     container._classifier_file.value = classifier
 
     container.batch_predict()
 
     # Check if the loop completes without exceptions
     assert container._progress_bar.value == num_files
-    assert container._progress_bar.label == f"Predicted {num_files} Images"
+    assert container._progress_bar.label == f'Predicted {num_files} Images'
 
 
 def test_update_metadata_from_file():
@@ -207,33 +208,32 @@ def test_update_metadata_from_file():
 
     # Mock the get_directory_and_files function to return a sample file
     with patch(
-        "napari_ndev.helpers.get_directory_and_files"
+        'napari_ndev.helpers.get_directory_and_files'
     ) as mock_get_directory_and_files:
         mock_get_directory_and_files.return_value = (
-            "/path/to/directory",
-            ["/path/to/file.tif"],
+            '/path/to/directory',
+            ['/path/to/file.tif'],
         )
 
         # Mock the AICSImage class to return sample channel names
-        with patch("aicsimageio.AICSImage") as mock_AICSImage:
-            mock_AICSImage.return_value.channel_names = ["C0", "C1", "C2"]
+        with patch('aicsimageio.AICSImage') as mock_AICSImage:
+            mock_AICSImage.return_value.channel_names = ['C0', 'C1', 'C2']
 
             # Call the _update_metadata_from_file method
             wdg._update_metadata_from_file()
 
             # Check if the image channels choices are updated correctly
-            assert list(wdg._image_channels.choices) == ["C0", "C1", "C2"]
+            assert list(wdg._image_channels.choices) == ['C0', 'C1', 'C2']
 
 
 @pytest.mark.notox
 def test_batch_predict_exception_logging(tmp_path):
-
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Apoc/Images"
+        'src/napari_ndev/_tests/resources/Apoc/Images'
     )
 
-    num_files = len(list(image_directory.glob("*.tiff")))
-    output_directory = tmp_path / "output"
+    num_files = len(list(image_directory.glob('*.tiff')))
+    output_directory = tmp_path / 'output'
     output_directory.mkdir()
 
     # Create an instance of ApocContainer
@@ -241,22 +241,26 @@ def test_batch_predict_exception_logging(tmp_path):
     container._image_directory.value = image_directory
     container._output_directory.value = output_directory
     # container._image_channels.value = ["IBA1"] # fix these images
-    container._image_channels.value = ["Labels"]
+    container._image_channels.value = ['Labels']
 
-    # Mock the custom_classifier.predict() method to raise an exception
+    # Create a custom exception class
+    class CustomException(Exception):
+        pass
+
+    # Mock the custom_classifier.predict() method to raise the custom exception
     class MockClassifier:
         def predict(self, image):
-            raise Exception("Test exception")
+            raise CustomException('Test exception')
 
     container._get_prediction_classifier_instance = lambda: MockClassifier()
 
     # Set up logging
-    log_file = output_directory / "log.txt"
+    log_file = output_directory / 'log.txt'
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
     handler = logging.FileHandler(log_file)
     handler.setLevel(logging.INFO)
-    formatter = logging.Formatter("%(asctime)s - %(message)s")
+    formatter = logging.Formatter('%(asctime)s - %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
@@ -266,11 +270,11 @@ def test_batch_predict_exception_logging(tmp_path):
     # Check if the exception is logged
     with open(log_file) as f:
         log_contents = f.read()
-        assert "Error predicting" in log_contents
+        assert 'Error predicting' in log_contents
 
     # Check if the loop continues
     assert container._progress_bar.value == num_files
-    assert container._progress_bar.label == f"Predicted {num_files} Images"
+    assert container._progress_bar.label == f'Predicted {num_files} Images'
 
     # Clean up
     logger.removeHandler(handler)

--- a/src/napari_ndev/_tests/test_apoc_feature_stack.py
+++ b/src/napari_ndev/_tests/test_apoc_feature_stack.py
@@ -8,28 +8,28 @@ def test_generate_feature_string_button(make_napari_viewer):
     wdg = ApocFeatureStack(make_napari_viewer())
     wdg._original.value = True
     wdg._generate_string_button.clicked.emit()
-    assert wdg._feature_string.value != ""
+    assert wdg._feature_string.value != ''
 
 
 def test_generate_features_none(make_napari_viewer):
     wdg = ApocFeatureStack(make_napari_viewer())
     wdg.generate_feature_string()
-    assert wdg._feature_string.value == ""
+    assert wdg._feature_string.value == ''
 
 
 def test_generate_feature_string_original(make_napari_viewer):
     wdg = ApocFeatureStack(make_napari_viewer())
     wdg._original.value = True
     wdg.generate_feature_string()
-    assert "original" in wdg._feature_string.value
+    assert 'original' in wdg._feature_string.value
 
 
 @pytest.mark.parametrize(
-    "input_value, expected_output",
+    ('input_value', 'expected_output'),
     [
-        ("3", "gaussian_blur=3"),
-        ("3,4,5", "gaussian_blur=3 gaussian_blur=4 gaussian_blur=5"),
-        ("3, 4,   5", "gaussian_blur=3 gaussian_blur=4 gaussian_blur=5"),
+        ('3', 'gaussian_blur=3'),
+        ('3,4,5', 'gaussian_blur=3 gaussian_blur=4 gaussian_blur=5'),
+        ('3, 4,   5', 'gaussian_blur=3 gaussian_blur=4 gaussian_blur=5'),
     ],
 )
 def test_generate_feature_string_gaussian_blur(

--- a/src/napari_ndev/_tests/test_helpers.py
+++ b/src/napari_ndev/_tests/test_helpers.py
@@ -22,13 +22,13 @@ from napari_ndev.helpers import (
 
 def test_check_for_missing_files_path(tmp_path):
     # Create a directory and some files
-    directory = Path(tmp_path / "test_dir")
+    directory = Path(tmp_path / 'test_dir')
     directory.mkdir()
-    file1 = directory / "file1.txt"
-    file1.write_text("This is a test file.")
-    file2 = directory / "file2.txt"
-    file2.write_text("This is another test file.")
-    file3 = directory / "file3.txt"
+    file1 = directory / 'file1.txt'
+    file1.write_text('This is a test file.')
+    file2 = directory / 'file2.txt'
+    file2.write_text('This is another test file.')
+    file3 = directory / 'file3.txt'
 
     # Check for missing files
     missing_files = check_for_missing_files([file1, file2], directory)
@@ -36,102 +36,102 @@ def test_check_for_missing_files_path(tmp_path):
 
     # Check for missing files
     missing_files = check_for_missing_files([file1, file3], directory)
-    assert missing_files == [("file3.txt", "test_dir")]
+    assert missing_files == [('file3.txt', 'test_dir')]
 
 
 def test_check_for_missing_file_str(tmp_path):
     # Create a directory and some files
-    directory = tmp_path / "test_dir"
+    directory = tmp_path / 'test_dir'
     directory.mkdir()
-    file1 = directory / "file1.txt"
-    file1.write_text("This is a test file.")
-    file2 = directory / "file2.txt"
-    file2.write_text("This is another test file.")
+    file1 = directory / 'file1.txt'
+    file1.write_text('This is a test file.')
+    file2 = directory / 'file2.txt'
+    file2.write_text('This is another test file.')
 
     # Check for missing files
     missing_files = check_for_missing_files(
-        ["file1.txt", "file2.txt"], directory
+        ['file1.txt', 'file2.txt'], directory
     )
     assert missing_files == []
 
     # Check for missing files
     missing_files = check_for_missing_files(
-        ["file1.txt", "file3.txt"], directory
+        ['file1.txt', 'file3.txt'], directory
     )
-    assert missing_files == [("file3.txt", "test_dir")]
+    assert missing_files == [('file3.txt', 'test_dir')]
 
 
 def test_create_id_string():
     img = BioImage(np.random.random((2, 2)))
-    id = "test_id"
-    id_string = create_id_string(img, id)
-    assert id_string == "test_id__0__Image:0"
+    identifier = 'test_id'
+    id_string = create_id_string(img, identifier)
+    assert id_string == 'test_id__0__Image:0'
 
 
 def test_create_id_string_no_id():
     img = BioImage(np.random.random((2, 2)))
-    id = None
-    id_string = create_id_string(img, id)
-    assert id_string == "None__0__Image:0"
+    identifier = None
+    id_string = create_id_string(img, identifier)
+    assert id_string == 'None__0__Image:0'
 
 
 def test_create_id_string_ome_metadata_no_name():
     file = Path(
-        "./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff"
+        './src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
     )
     img = BioImage(file)
 
-    id = file.stem
-    id_string = create_id_string(img, id)
+    identifier = file.stem
+    id_string = create_id_string(img, identifier)
     assert (
-        img._plugin.entrypoint.name == "bioio-ome-tiff"
+        img._plugin.entrypoint.name == 'bioio-ome-tiff'
     )  # this has no ome_metadata.images.name
     assert img.ome_metadata.images[0].name is None
-    assert img.channel_names == ["membrane", "nuclei"]
-    assert id_string == "cells3d2ch__0__Image:0"
+    assert img.channel_names == ['membrane', 'nuclei']
+    assert id_string == 'cells3d2ch__0__Image:0'
 
 
 def test_create_id_string_ometiffwriter_name(tmp_path):
     OmeTiffWriter.save(
         data=np.random.random((2, 2)),
-        uri=tmp_path / "test.tiff",
-        image_name="test_image",
+        uri=tmp_path / 'test.tiff',
+        image_name='test_image',
     )
 
-    img = BioImage(tmp_path / "test.tiff")
-    id = "test_id"
+    img = BioImage(tmp_path / 'test.tiff')
+    identifier = 'test_id'
 
-    id_string = create_id_string(img, id)
-    assert img.current_scene == "Image:0"
-    assert id_string == "test_id__0__test_image"
+    id_string = create_id_string(img, identifier)
+    assert img.current_scene == 'Image:0'
+    assert id_string == 'test_id__0__test_image'
 
 
 def test_get_channel_names_CYX():
     file = Path(
-        r"./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff"
+        r'./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
     )
     img = BioImage(file)
     assert get_channel_names(img) == img.channel_names
 
 
 def test_get_channel_names_RGB():
-    file = Path(r"./src/napari_ndev/_tests/resources/RGB.tiff")
+    file = Path(r'./src/napari_ndev/_tests/resources/RGB.tiff')
     img = AICSImage(file)
-    assert get_channel_names(img) == ["red", "green", "blue"]
+    assert get_channel_names(img) == ['red', 'green', 'blue']
 
 
 def test_get_directory_and_files_default_pattern():
-    directory = Path(r"./src/napari_ndev/_tests/resources/test_czis")
+    directory = Path(r'./src/napari_ndev/_tests/resources/test_czis')
     directory, files = get_directory_and_files(directory)
-    assert directory == Path(r"./src/napari_ndev/_tests/resources/test_czis")
-    assert files == [f for f in directory.glob("*")]
+    assert directory == Path(r'./src/napari_ndev/_tests/resources/test_czis')
+    assert files == list(directory.glob('*'))
 
 
 def test_get_directory_and_files_custom_pattern():
-    directory = Path(r"./src/napari_ndev/_tests/resources/test_czis")
-    directory, files = get_directory_and_files(directory, pattern=".czi")
-    assert directory == Path(r"./src/napari_ndev/_tests/resources/test_czis")
-    assert files == [f for f in directory.glob("*.czi")]
+    directory = Path(r'./src/napari_ndev/_tests/resources/test_czis')
+    directory, files = get_directory_and_files(directory, pattern='.czi')
+    assert directory == Path(r'./src/napari_ndev/_tests/resources/test_czis')
+    assert files == list(directory.glob('*.czi'))
 
 
 def test_get_directory_and_files_none_dir():
@@ -142,7 +142,7 @@ def test_get_directory_and_files_none_dir():
 
 def test_get_directory_and_files_dir_not_exists():
     directory = Path(
-        r"./src/napari_ndev/_tests/resources/test_czis_not_exists"
+        r'./src/napari_ndev/_tests/resources/test_czis_not_exists'
     )
     with pytest.raises(FileNotFoundError):
         get_directory_and_files(directory)
@@ -150,16 +150,16 @@ def test_get_directory_and_files_dir_not_exists():
 
 def test_get_squeezed_dim_order_ZYX():
     file = Path(
-        r"./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff"
+        r'./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
     )
     img = BioImage(file)
-    assert get_squeezed_dim_order(img) == "ZYX"
+    assert get_squeezed_dim_order(img) == 'ZYX'
 
 
 def test_get_squeezed_dim_order_RGB():
-    file = Path(r"./src/napari_ndev/_tests/resources/RGB.tiff")
+    file = Path(r'./src/napari_ndev/_tests/resources/RGB.tiff')
     img = AICSImage(file)
-    assert get_squeezed_dim_order(img) == "YX"
+    assert get_squeezed_dim_order(img) == 'YX'
 
 
 def test_setup_logger():
@@ -185,7 +185,7 @@ def test_setup_logger():
         # Check that the formatter is set up correctly
         formatter = handler.formatter
         assert isinstance(formatter, logging.Formatter)
-        assert formatter._fmt == "%(asctime)s - %(message)s"
+        assert formatter._fmt == '%(asctime)s - %(message)s'
 
     finally:
         # remove the handler and close it

--- a/src/napari_ndev/_tests/test_image_overview.py
+++ b/src/napari_ndev/_tests/test_image_overview.py
@@ -12,27 +12,27 @@ from napari_ndev.image_overview import ImageOverview, image_overview
 def image_and_label_sets():
     img = BioImage(
         pathlib.Path(
-            r"src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff"
+            r'src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
         )
     )
     image_data = np.squeeze(img.data)
 
     image_set1 = {
-        "image": [image_data[0], image_data[1]],
-        "colormap": ["PiYG", "viridis"],
-        "title": ["Image 1", "Image 2"],
+        'image': [image_data[0], image_data[1]],
+        'colormap': ['PiYG', 'viridis'],
+        'title': ['Image 1', 'Image 2'],
     }
 
     lbl = BioImage(
         pathlib.Path(
-            r"src/napari_ndev/_tests/resources/Workflow/Labels/cells3d2ch.tiff"
+            r'src/napari_ndev/_tests/resources/Workflow/Labels/cells3d2ch.tiff'
         )
     )
 
     label_set = {
-        "image": [None, np.squeeze(lbl.data)],
-        "colormap": [None, "Labels"],
-        "title": [None, "Labels"],
+        'image': [None, np.squeeze(lbl.data)],
+        'colormap': [None, 'Labels'],
+        'title': [None, 'Labels'],
     }
 
     return image_set1, label_set
@@ -45,17 +45,17 @@ def test_image_overview(image_and_label_sets):
     assert len(fig.axes) == 4
 
     # Check the properties of each subplot
-    assert fig.axes[0].get_title() == "Image 1"
-    assert fig.axes[0].get_images()[0].get_cmap().name == "PiYG"
+    assert fig.axes[0].get_title() == 'Image 1'
+    assert fig.axes[0].get_images()[0].get_cmap().name == 'PiYG'
 
-    assert fig.axes[1].get_title() == "Image 2"
-    assert fig.axes[1].get_images()[0].get_cmap().name == "viridis"
+    assert fig.axes[1].get_title() == 'Image 2'
+    assert fig.axes[1].get_images()[0].get_cmap().name == 'viridis'
 
     # fig. axes[2] should be empty
     assert not fig.axes[2].get_title()
     assert not fig.axes[2].get_images()
 
-    assert fig.axes[3].get_title() == "Labels"
+    assert fig.axes[3].get_title() == 'Labels'
 
 
 def test_imageoverview_init(image_and_label_sets):
@@ -66,10 +66,10 @@ def test_imageoverview_init(image_and_label_sets):
 def test_imageoverview_save(image_and_label_sets):
     im = ImageOverview(image_and_label_sets, show=False)
     # test that the figure can be saved with .save()
-    save_path = pathlib.Path(r"src\napari_ndev\_tests\resources")
-    save_file_path = save_path / "image_overview.png"
+    save_path = pathlib.Path(r'src\napari_ndev\_tests\resources')
+    save_file_path = save_path / 'image_overview.png'
 
-    im.save(str(save_path), "image_overview.png")
+    im.save(str(save_path), 'image_overview.png')
     # assert that it was saved
     assert save_file_path.exists()
     # remove the saved file

--- a/src/napari_ndev/_tests/test_import.py
+++ b/src/napari_ndev/_tests/test_import.py
@@ -1,15 +1,13 @@
 import time
 
+
 def test_import_time():
-    
     start_time = time.time()
-    
-    import napari_ndev
-    
+
+
     end_time = time.time()
-    
+
     import_time = end_time - start_time
-    
-    print(f"napari_ndev was imported in {import_time: .3f} seconds")
-    
-    assert import_time < 1.0, "napari_ndev took too long to import"
+
+
+    assert import_time < 1.0, 'napari_ndev took too long to import'

--- a/src/napari_ndev/_tests/test_measure.py
+++ b/src/napari_ndev/_tests/test_measure.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
@@ -16,11 +16,11 @@ from napari_ndev.measure import (
 
 
 @pytest.mark.parametrize(
-    "arg, expected",
+    ('arg', 'expected'),
     [
         (None, None),
         (1, [1]),
-        ("string", ["string"]),
+        ('string', ['string']),
         ([1, 2, 3], [1, 2, 3]),
         (np.array([1, 2, 3]), [np.array([1, 2, 3])]),
         (
@@ -30,7 +30,7 @@ from napari_ndev.measure import (
     ],
 )
 def test_convert_to_list(
-    arg: Union[List, ArrayLike, str, None], expected: Union[List, None]
+    arg: list | ArrayLike | str | None, expected: list | None
 ):
     result = _convert_to_list(arg)
     if isinstance(result, list):
@@ -52,7 +52,7 @@ intensity_list = [intensity1, intensity2]
 
 
 @pytest.mark.parametrize(
-    "label_images, label_names, intensity_images, intensity_names, expected",
+    ('label_images', 'label_names', 'intensity_images', 'intensity_names', 'expected'),
     [
         (
             label1,
@@ -60,10 +60,10 @@ intensity_list = [intensity1, intensity2]
             None,
             None,
             {
-                "label_images": label1,
-                "label_names": ["label_0"],
-                "intensity_images": None,
-                "intensity_names": None,
+                'label_images': label1,
+                'label_names': ['label_0'],
+                'intensity_images': None,
+                'intensity_names': None,
             },
         ),
         (
@@ -72,46 +72,46 @@ intensity_list = [intensity1, intensity2]
             intensity1,
             None,
             {
-                "label_images": label1,
-                "label_names": ["label_0"],
-                "intensity_images": intensity1,
-                "intensity_names": ["intensity_0"],
+                'label_images': label1,
+                'label_names': ['label_0'],
+                'intensity_images': intensity1,
+                'intensity_names': ['intensity_0'],
             },
         ),
         (
             label1,
-            "custom_label",
+            'custom_label',
             intensity1,
-            "custom_intensity",
+            'custom_intensity',
             {
-                "label_images": label1,
-                "label_names": ["custom_label"],
-                "intensity_images": intensity1,
-                "intensity_names": ["custom_intensity"],
+                'label_images': label1,
+                'label_names': ['custom_label'],
+                'intensity_images': intensity1,
+                'intensity_names': ['custom_intensity'],
             },
         ),
         (
             label1,
-            "custom_label",
+            'custom_label',
             None,
             None,
             {
-                "label_images": label1,
-                "label_names": ["custom_label"],
-                "intensity_images": None,
-                "intensity_names": None,
+                'label_images': label1,
+                'label_names': ['custom_label'],
+                'intensity_images': None,
+                'intensity_names': None,
             },
         ),
         (
             label_list,
-            ["label_c1", "label_c2"],
+            ['label_c1', 'label_c2'],
             intensity_list,
-            ["intensity_c1", "intensity_c2"],
+            ['intensity_c1', 'intensity_c2'],
             {
-                "label_images": label_list,
-                "label_names": ["label_c1", "label_c2"],
-                "intensity_images": intensity_list,
-                "intensity_names": ["intensity_c1", "intensity_c2"],
+                'label_images': label_list,
+                'label_names': ['label_c1', 'label_c2'],
+                'intensity_images': intensity_list,
+                'intensity_names': ['intensity_c1', 'intensity_c2'],
             },
         ),
     ],
@@ -122,72 +122,71 @@ def test_generate_measure_dict(
     result = _generate_measure_dict(
         label_images, label_names, intensity_images, intensity_names
     )
-    assert result["label_images"][0].all() == expected["label_images"][0].all()
-    assert result["label_names"] == expected["label_names"]
-    assert isinstance(result["label_names"], list)
+    assert result['label_images'][0].all() == expected['label_images'][0].all()
+    assert result['label_names'] == expected['label_names']
+    assert isinstance(result['label_names'], list)
     # assert intensity images are the same, if they exist
-    if result["intensity_images"] is not None:
+    if result['intensity_images'] is not None:
         assert (
-            result["intensity_images"][0].all()
-            == expected["intensity_images"][0].all()
+            result['intensity_images'][0].all()
+            == expected['intensity_images'][0].all()
         )
-        assert result["intensity_names"] == expected["intensity_names"]
+        assert result['intensity_names'] == expected['intensity_names']
     else:
-        assert result["intensity_images"] is None
-        assert result["intensity_names"] is None
+        assert result['intensity_images'] is None
+        assert result['intensity_names'] is None
 
 
 def test_extract_info_from_id_string():
-    id_string = "P14-A6__2024-07-16 25x 18HIC ncoa4 FT dapi obl 01"
+    id_string = 'P14-A6__2024-07-16 25x 18HIC ncoa4 FT dapi obl 01'
     id_regex = {
-        "scene": r"(P\d{1,3}-\w+)__",
-        "well": r"-(\w+)__",
-        "HIC": r"(\d{1,3})HIC",
-        "exp": r"obl (\d{2,3})",
+        'scene': r'(P\d{1,3}-\w+)__',
+        'well': r'-(\w+)__',
+        'HIC': r'(\d{1,3})HIC',
+        'exp': r'obl (\d{2,3})',
     }
-    expected = {"scene": "P14-A6", "well": "A6", "HIC": "18", "exp": "01"}
+    expected = {'scene': 'P14-A6', 'well': 'A6', 'HIC': '18', 'exp': '01'}
     result = _extract_info_from_id_string(id_string, id_regex)
     assert result == expected
 
 
 def test_rename_intensity_columns():
     data = {
-        "area": [100, 200],
-        "intensity_mean-0": [0.5, 0.7],
-        "intensity_mean-1": [0.8, 0.6],
+        'area': [100, 200],
+        'intensity_mean-0': [0.5, 0.7],
+        'intensity_mean-1': [0.8, 0.6],
     }
     df = pd.DataFrame(data)
-    intensity_names = ["membrane", "nuclei"]
+    intensity_names = ['membrane', 'nuclei']
     result = _rename_intensity_columns(df, intensity_names)
 
     assert list(result.columns) == [
-        "area",
-        "intensity_mean-membrane",
-        "intensity_mean-nuclei",
+        'area',
+        'intensity_mean-membrane',
+        'intensity_mean-nuclei',
     ]
 
 
 def test_map_tx_dict_to_df_id_col():
     tx = {
-        "Treatment1": {"Condition1": ["A1", "B2"], "Condition2": ["C3"]},
-        "Treatment2": {"Condition3": ["D4:E5"]},
+        'Treatment1': {'Condition1': ['A1', 'B2'], 'Condition2': ['C3']},
+        'Treatment2': {'Condition3': ['D4:E5']},
     }
     tx_n_well = 96
     target_df = pd.DataFrame(
         {
-            "well": ["A1", "A2", "A3", "A4", "A5", "A6"],
-            "value": [10, 20, 30, 40, 50, 60],
+            'well': ['A1', 'A2', 'A3', 'A4', 'A5', 'A6'],
+            'value': [10, 20, 30, 40, 50, 60],
         }
     )
-    id_column = "well"
+    id_column = 'well'
     result = map_tx_dict_to_df_id_col(tx, tx_n_well, target_df, id_column)
-    print(result)
     assert isinstance(result, pd.DataFrame)
-    assert "Treatment1" in result.columns
-    assert "Treatment2" in result.columns
+    assert 'Treatment1' in result.columns
+    assert 'Treatment2' in result.columns
     assert (
-        result.loc[result["well"] == "A1", "Treatment1"].values[0]
-        == "Condition1"
+        result.loc[result['well'] == 'A1', 'Treatment1'].values[0]
+        == 'Condition1'
     )
 
 
@@ -203,18 +202,16 @@ intensity_image_3d = np.array(
         [[10, 10, 20], [10, 20, 20], [20, 20, 10]],
     ]
 )
-id_string = "P14-A6__2024-07-16 25x 18HIC ncoa4 FT dapi obl 01"
+id_string = 'P14-A6__2024-07-16 25x 18HIC ncoa4 FT dapi obl 01'
 id_regex = {
-    "well": r"-(\w+)__",
-    "HIC": r"(\d{1,3})HIC",
-    "exp": r"obl (\d{2,3})",
+    'well': r'-(\w+)__',
+    'HIC': r'(\d{1,3})HIC',
+    'exp': r'obl (\d{2,3})',
 }
 
 
 @pytest.mark.parametrize(
-    "label_images, label_names, intensity_images, intensity_names, "
-    "properties, scale, id_string, id_regex_dict, "
-    "save_data_path, expected_columns",
+    ('label_images', 'label_names', 'intensity_images', 'intensity_names', 'properties', 'scale', 'id_string', 'id_regex_dict', 'save_data_path', 'expected_columns'),
     [
         # 2D label image, no intensity image
         (
@@ -222,12 +219,12 @@ id_regex = {
             None,
             None,
             None,
-            ["area", "eccentricity"],
+            ['area', 'eccentricity'],
             (1.0, 1.0),
             id_string,
             id_regex,
             None,
-            ["id", "well", "HIC", "exp", "area", "eccentricity"],
+            ['id', 'well', 'HIC', 'exp', 'area', 'eccentricity'],
         ),
         # 2D label image, with intensity image
         (
@@ -235,12 +232,12 @@ id_regex = {
             None,
             [intensity_image_2d],
             None,
-            ["area", "intensity_mean"],
+            ['area', 'intensity_mean'],
             (1.0, 1.0),
-            "test_id",
+            'test_id',
             None,
             None,
-            ["id", "area", "intensity_mean"],
+            ['id', 'area', 'intensity_mean'],
         ),
         # 2D label image, with 1 intensity images and names
         # TODO: Figure out why intensity_mean is not intensity_mean-0
@@ -248,26 +245,26 @@ id_regex = {
             [label_image_2d],
             None,
             [intensity_image_2d],
-            ["test1"],
-            ["area", "intensity_mean"],
+            ['test1'],
+            ['area', 'intensity_mean'],
             (1.0, 1.0),
-            "test_id",
+            'test_id',
             None,
             None,
-            ["id", "area", "intensity_mean"],
+            ['id', 'area', 'intensity_mean'],
         ),
         # 2D label image, with 2 intensity images and names
         (
             [label_image_2d],
             None,
             [intensity_image_2d, intensity_image_2d],
-            ["test1", "test2"],
-            ["area", "intensity_mean"],
+            ['test1', 'test2'],
+            ['area', 'intensity_mean'],
             (1.0, 1.0),
-            "test_id",
+            'test_id',
             None,
             None,
-            ["id", "area", "intensity_mean-test1", "intensity_mean-test2"],
+            ['id', 'area', 'intensity_mean-test1', 'intensity_mean-test2'],
         ),
         # 3D label image, no intensity image
         (
@@ -275,12 +272,12 @@ id_regex = {
             None,
             None,
             None,
-            ["area"],
+            ['area'],
             (1.0, 1.0, 1.0),
-            "test_id",
+            'test_id',
             None,
             None,
-            ["id", "area"],
+            ['id', 'area'],
         ),
         # 3D label image, with intensity image
         (
@@ -288,12 +285,12 @@ id_regex = {
             None,
             [intensity_image_3d],
             None,
-            ["area", "intensity_mean"],
+            ['area', 'intensity_mean'],
             (1.0, 1.0, 1.0),
-            "test_id",
+            'test_id',
             None,
             None,
-            ["id", "area", "intensity_mean"],
+            ['id', 'area', 'intensity_mean'],
         ),
     ],
 )
@@ -327,24 +324,24 @@ def test_measure_regionprops(
     # Check if the DataFrame contains the expected columns
     assert all(column in result_df.columns for column in expected_columns)
     # Check if the id_string column contains the correct value
-    assert (result_df["id"] == id_string).all()
+    assert (result_df['id'] == id_string).all()
 
 
 def test_measure_regionprops_tx_dict():
     label_images = [label_image_2d]
     intensity_images = [intensity_image_2d]
-    properties = ["area", "intensity_mean"]
+    properties = ['area', 'intensity_mean']
     scale = (1.0, 1.0)
-    id_string = "P14-A6__2024-07-16 25x 18HIC ncoa4 FT dapi obl 01"
+    id_string = 'P14-A6__2024-07-16 25x 18HIC ncoa4 FT dapi obl 01'
     id_regex_dict = {
-        "well": r"-(\w+)__",
-        "HIC": r"(\d{1,3})HIC",
-        "exp": r"obl (\d{2,3})",
+        'well': r'-(\w+)__',
+        'HIC': r'(\d{1,3})HIC',
+        'exp': r'obl (\d{2,3})',
     }
-    tx_id = "well"
+    tx_id = 'well'
     tx_dict = {
-        "Treatment1": {"Condition1": ["A1", "B2"], "Condition2": ["C3"]},
-        "Treatment2": {"Condition3": ["D4:E5"]},
+        'Treatment1': {'Condition1': ['A1', 'B2'], 'Condition2': ['C3']},
+        'Treatment2': {'Condition3': ['D4:E5']},
     }
     tx_n_well = 96
     result_df = measure_regionprops(
@@ -359,38 +356,37 @@ def test_measure_regionprops_tx_dict():
         tx_dict=tx_dict,
     )
 
-    print(result_df)
 
     assert isinstance(result_df, pd.DataFrame)
     # Check if the DataFrame contains the expected columns
     assert all(
         column in result_df.columns
         for column in [
-            "id",
-            "area",
-            "intensity_mean",
-            "Treatment1",
-            "Treatment2",
+            'id',
+            'area',
+            'intensity_mean',
+            'Treatment1',
+            'Treatment2',
         ]
     )
     # Check if the id_string column contains the correct value
-    assert (result_df["id"] == id_string).all()
+    assert (result_df['id'] == id_string).all()
     # Check if the treatments were assigned correctly
     assert (
-        result_df.loc[result_df["well"] == "A1", "Treatment1"] == "Condition1"
+        result_df.loc[result_df['well'] == 'A1', 'Treatment1'] == 'Condition1'
     ).all()
     assert (
-        result_df.loc[result_df["well"] == "B2", "Treatment1"] == "Condition1"
+        result_df.loc[result_df['well'] == 'B2', 'Treatment1'] == 'Condition1'
     ).all()
     assert (
-        result_df.loc[result_df["well"] == "C3", "Treatment1"] == "Condition2"
+        result_df.loc[result_df['well'] == 'C3', 'Treatment1'] == 'Condition2'
     ).all()
     assert (
-        result_df.loc[result_df["well"] == "D4", "Treatment2"] == "Condition3"
+        result_df.loc[result_df['well'] == 'D4', 'Treatment2'] == 'Condition3'
     ).all()
     assert (
-        result_df.loc[result_df["well"] == "E5", "Treatment2"] == "Condition3"
+        result_df.loc[result_df['well'] == 'E5', 'Treatment2'] == 'Condition3'
     ).all()
     assert (
-        result_df.loc[result_df["well"] == "E4", "Treatment2"] == "Condition3"
+        result_df.loc[result_df['well'] == 'E4', 'Treatment2'] == 'Condition3'
     ).all()

--- a/src/napari_ndev/_tests/test_measure_container.py
+++ b/src/napari_ndev/_tests/test_measure_container.py
@@ -7,11 +7,11 @@ from napari_ndev._measure_container import MeasureContainer
 
 def test_widg_init_no_viewer():
     wdg = MeasureContainer()
-    assert wdg._image_directory.label == "Image directory"
+    assert wdg._image_directory.label == 'Image directory'
     assert wdg._image_directory.value is None
     assert len(wdg._props_container) == len(wdg._sk_props)
-    assert hasattr(wdg._prop, "area")
-    assert hasattr(wdg._prop, "intensity_min")
+    assert hasattr(wdg._prop, 'area')
+    assert hasattr(wdg._prop, 'intensity_min')
     assert wdg.viewer is None
 
 
@@ -23,20 +23,20 @@ def test_widg_init_with_viewer(make_napari_viewer):
 
 def test_get_0th_img_from_dir(tmp_path):
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Apoc/Images"
+        'src/napari_ndev/_tests/resources/Apoc/Images'
     )
     container = MeasureContainer()
-    img, id = container._get_0th_img_from_dir(image_directory)
+    img, file_id = container._get_0th_img_from_dir(image_directory)
 
     assert img is not None
-    assert isinstance(id, pathlib.Path)
+    assert isinstance(file_id, pathlib.Path)
 
 
 def test_update_dim_and_scales():
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Apoc/Images"
+        'src/napari_ndev/_tests/resources/Apoc/Images'
     )
-    file_name = "SPF-4MM-22 slide 9-S6_Top Slide_TR2_p00_0_A01f00d0.tiff"
+    file_name = 'SPF-4MM-22 slide 9-S6_Top Slide_TR2_p00_0_A01f00d0.tiff'
     container = MeasureContainer()
     img = BioImage(image_directory / file_name)
     container._update_dim_and_scales(img)
@@ -47,72 +47,70 @@ def test_update_dim_and_scales():
 def test_update_choices():
     container = MeasureContainer()
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Images"
+        'src/napari_ndev/_tests/resources/Workflow/Images'
     )
     label_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Labels"
+        'src/napari_ndev/_tests/resources/Workflow/Labels'
     )
     region_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/ShapesAsLabels"
+        'src/napari_ndev/_tests/resources/Workflow/ShapesAsLabels'
     )
     container._image_directory.value = image_directory
     container._label_directory.value = label_directory
     container._region_directory.value = region_directory
 
-    container._update_choices(image_directory, "Intensity")
-    container._update_choices(label_directory, "Labels", update_label=True)
-    container._update_choices(region_directory, "Region")
-    print(container._label_choices)
-    print(container._intensity_choices)
+    container._update_choices(image_directory, 'Intensity')
+    container._update_choices(label_directory, 'Labels', update_label=True)
+    container._update_choices(region_directory, 'Region')
 
     # Check the choices in the label image ComboBox
-    assert container._label_image.choices == ("Labels: Labels",)
+    assert container._label_image.choices == ('Labels: Labels',)
 
     # Check the choices in the intensity images Select widget
     assert container._intensity_images.choices == (
         None,  # The default choice
-        "Intensity: membrane",
-        "Intensity: nuclei",
-        "Labels: Labels",
-        "Region: Shapes",
+        'Intensity: membrane',
+        'Intensity: nuclei',
+        'Labels: Labels',
+        'Region: Shapes',
     )
 
 
 def test_batch_measure_label_only(tmp_path):
     container = MeasureContainer()
     label_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Labels"
+        'src/napari_ndev/_tests/resources/Workflow/Labels'
     )
     # make a dummy output folder
-    output_folder = tmp_path / "Output"
+    output_folder = tmp_path / 'Output'
     output_folder.mkdir()
 
     container._label_directory.value = label_directory
-    container._label_image.value = "Labels: Labels"
+    container._label_image.value = 'Labels: Labels'
     container._output_directory.value = output_folder
     df, df_grouped = container.batch_measure()
 
     assert output_folder.exists()
-    assert (output_folder / "measure_props_Labels.csv").exists()
+    assert (output_folder / 'measure_props_Labels.csv').exists()
     assert df is not None
     assert df_grouped is None
-    assert list(df.columns) == ["id", "area"]
+    assert list(df.columns) == ['id', 'area']
 
 
 # TODO: figure out why _intensity_images.value is not in index order, but alphabetical
 def test_batch_measure_intensity(tmp_path):
     container = MeasureContainer()
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Images"
+        'src/napari_ndev/_tests/resources/Workflow/Images'
     )
     label_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Labels"
+        'src/napari_ndev/_tests/resources/Workflow/Labels'
     )
     region_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/ShapesAsLabels"
+        'src/napari_ndev/_tests/resources/Workflow/ShapesAsLabels'
     )
     # make a dummy output folder
-    output_folder = tmp_path / "Output"
+    output_folder = tmp_path / 'Output'
     output_folder.mkdir()
 
     container._image_directory.value = image_directory
@@ -121,25 +119,25 @@ def test_batch_measure_intensity(tmp_path):
     container._scale_tuple.value = (3, 0.25, 0.25)
     container._prop.intensity_mean.value = True
 
-    container._label_image.value = "Labels: Labels"
+    container._label_image.value = 'Labels: Labels'
     container._intensity_images.value = [
-        "Region: Shapes",
-        "Intensity: membrane",
-        "Intensity: nuclei",
+        'Region: Shapes',
+        'Intensity: membrane',
+        'Intensity: nuclei',
     ]
     container._output_directory.value = output_folder
     df, df_grouped = container.batch_measure()
 
     assert output_folder.exists()
-    assert (output_folder / "measure_props_Labels.csv").exists()
+    assert (output_folder / 'measure_props_Labels.csv').exists()
     assert df is not None
     assert df_grouped is None
     assert list(df.columns) == [
-        "id",
-        "area",
-        "intensity_mean-membrane",
-        "intensity_mean-nuclei",
-        "intensity_mean-Shapes",
+        'id',
+        'area',
+        'intensity_mean-membrane',
+        'intensity_mean-nuclei',
+        'intensity_mean-Shapes',
     ]
 
 
@@ -148,17 +146,17 @@ def test_batch_measure_groupby(tmp_path):
     container = MeasureContainer()
 
     label_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Labels"
+        'src/napari_ndev/_tests/resources/Workflow/Labels'
     )
     image_directory = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/Images"
+        'src/napari_ndev/_tests/resources/Workflow/Images'
     )
 
-    output_folder = tmp_path / "Output"
+    output_folder = tmp_path / 'Output'
     output_folder.mkdir()
 
     container._label_directory.value = label_directory
-    container._label_image.value = "Labels: Labels"
+    container._label_image.value = 'Labels: Labels'
     container._image_directory.value = image_directory
     container._output_directory.value = output_folder
     # container._intensity_images.value = ["Intensity: membrane", "Intensity: nuclei"]
@@ -167,14 +165,13 @@ def test_batch_measure_groupby(tmp_path):
     container._create_grouped.value = True
 
     df, df_grouped = container.batch_measure()
-    print(df_grouped.columns)
 
     assert df is not None
     assert df_grouped is not None
-    assert list(df.columns) == ["id", "area"]
+    assert list(df.columns) == ['id', 'area']
     assert list(df_grouped.columns) == [
-        "id",
-        "area_mean",
-        "area_std",
-        "label_count",
+        'id',
+        'area_mean',
+        'area_std',
+        'label_count',
     ]

--- a/src/napari_ndev/_tests/test_plate_mapper.py
+++ b/src/napari_ndev/_tests/test_plate_mapper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 import pytest
 
@@ -12,8 +14,8 @@ def plate_mapper():
 @pytest.fixture
 def treatments():
     return {
-        "Treatment1": {"Condition1": ["A1", "B2"], "Condition2": ["C3"]},
-        "Treatment2": {"Condition3": ["D4:E5"]},
+        'Treatment1': {'Condition1': ['A1', 'B2'], 'Condition2': ['C3']},
+        'Treatment2': {'Condition3': ['D4:E5']},
     }
 
 
@@ -23,58 +25,64 @@ def test_plate_mapper_create_empty_plate_map(plate_mapper: PlateMapper):
     assert isinstance(plate_map_df, pd.DataFrame)
     assert len(plate_map_df) == 96
     assert len(plate_map_df.columns) == 3
-    assert "row" in plate_map_df.columns
-    assert "column" in plate_map_df.columns
-    assert "well_id" in plate_map_df.columns
+    assert 'row' in plate_map_df.columns
+    assert 'column' in plate_map_df.columns
+    assert 'well_id' in plate_map_df.columns
 
 
-def test_plate_mapper_assign_treatments(plate_mapper: PlateMapper, treatments: dict[str, dict[str, list[str]]]):
+def test_plate_mapper_assign_treatments(
+    plate_mapper: PlateMapper, treatments: dict[str, dict[str, list[str]]]
+):
     plate_map = plate_mapper.assign_treatments(treatments)
 
     assert isinstance(plate_map, pd.DataFrame)
-    assert "Treatment1" in plate_map.columns
-    assert "Treatment2" in plate_map.columns
+    assert 'Treatment1' in plate_map.columns
+    assert 'Treatment2' in plate_map.columns
     assert (
-        plate_map.loc[plate_map["well_id"] == "A1", "Treatment1"].values[0]
-        == "Condition1"
+        plate_map.loc[plate_map['well_id'] == 'A1', 'Treatment1'].values[0]
+        == 'Condition1'
     )
     assert (
-        plate_map.loc[plate_map["well_id"] == "B2", "Treatment1"].values[0]
-        == "Condition1"
+        plate_map.loc[plate_map['well_id'] == 'B2', 'Treatment1'].values[0]
+        == 'Condition1'
     )
     assert (
-        plate_map.loc[plate_map["well_id"] == "C3", "Treatment1"].values[0]
-        == "Condition2"
+        plate_map.loc[plate_map['well_id'] == 'C3', 'Treatment1'].values[0]
+        == 'Condition2'
     )
     assert (
-        plate_map.loc[plate_map["well_id"] == "D4", "Treatment2"].values[0]
-        == "Condition3"
+        plate_map.loc[plate_map['well_id'] == 'D4', 'Treatment2'].values[0]
+        == 'Condition3'
     )
     assert (
-        plate_map.loc[plate_map["well_id"] == "E5", "Treatment2"].values[0]
-        == "Condition3"
+        plate_map.loc[plate_map['well_id'] == 'E5', 'Treatment2'].values[0]
+        == 'Condition3'
     )
     assert (
-        plate_map.loc[plate_map["well_id"] == "E4", "Treatment2"].values[0]
-        == "Condition3"
+        plate_map.loc[plate_map['well_id'] == 'E4', 'Treatment2'].values[0]
+        == 'Condition3'
     )
 
 
-def test_plate_mapper_get_pivoted_plate_map(plate_mapper: PlateMapper, treatments: dict[str, dict[str, list[str]]]):
+def test_plate_mapper_get_pivoted_plate_map(
+    plate_mapper: PlateMapper, treatments: dict[str, dict[str, list[str]]]
+):
     plate_mapper.assign_treatments(treatments)
-    plate_map_pivot = plate_mapper.get_pivoted_plate_map("Treatment1")
+    plate_map_pivot = plate_mapper.get_pivoted_plate_map('Treatment1')
 
     assert isinstance(plate_map_pivot, pd.DataFrame)
     assert len(plate_map_pivot) == 8
     assert len(plate_map_pivot.columns) == 12
-    assert "A" in plate_map_pivot.index
-    assert "Condition1" in plate_map_pivot.values
-    assert "Condition2" in plate_map_pivot.values
+    assert 'A' in plate_map_pivot.index
+    assert 'Condition1' in plate_map_pivot.values
+    assert 'Condition2' in plate_map_pivot.values
 
 
-def test_plate_mapper_get_styled_plate_map(plate_mapper: PlateMapper, treatments: dict[str, dict[str, list[str]]]):
+def test_plate_mapper_get_styled_plate_map(
+    plate_mapper: PlateMapper, treatments: dict[str, dict[str, list[str]]]
+):
     plate_mapper.assign_treatments(treatments)
-    plate_map_styled = plate_mapper.get_styled_plate_map("Treatment1")
+    plate_map_styled = plate_mapper.get_styled_plate_map('Treatment1')
 
     assert isinstance(plate_map_styled, pd.io.formats.style.Styler)
-    assert plate_map_styled.caption == "Treatment1 Plate Map"
+    assert plate_map_styled.caption == 'Treatment1 Plate Map'

--- a/src/napari_ndev/_tests/test_utilities_container.py
+++ b/src/napari_ndev/_tests/test_utilities_container.py
@@ -40,15 +40,15 @@ labels_4d = np.array(
 
 @pytest.fixture(
     params=[
-        (image_2d, shapes_2d, labels_2d, "YX"),
-        (image_4d, shapes_4d, labels_4d, "TZYX"),
+        (image_2d, shapes_2d, labels_2d, 'YX'),
+        (image_4d, shapes_4d, labels_4d, 'TZYX'),
     ]
 )
 def test_data(request: pytest.FixtureRequest):
     return request.param
 
 
-@pytest.mark.parametrize("image_layer", [True, False])
+@pytest.mark.parametrize('image_layer', [True, False])
 def test_save_shapes_as_labels(
     make_napari_viewer, tmp_path: Path, test_data, image_layer: bool
 ):
@@ -59,18 +59,18 @@ def test_save_shapes_as_labels(
     viewer.add_shapes(test_shape)
     container = UtilitiesContainer(viewer)
 
-    container._viewer.layers.selection.active = viewer.layers["test_shape"]
+    container._viewer.layers.selection.active = viewer.layers['test_shape']
     container._squeezed_dims = test_dims
     container._save_directory.value = tmp_path
-    container._save_name.value = "test.tiff"
+    container._save_name.value = 'test.tiff'
 
     shapes_as_labels = container.save_shapes_as_labels()
 
-    expected_save_loc = tmp_path / "ShapesAsLabels" / "test.tiff"
+    expected_save_loc = tmp_path / 'ShapesAsLabels' / 'test.tiff'
     assert expected_save_loc.exists()
     assert shapes_as_labels.shape == test_image.shape
     assert np.array_equal(shapes_as_labels, test_labels)
-    assert AICSImage(expected_save_loc).channel_names == ["Shapes"]
+    assert AICSImage(expected_save_loc).channel_names == ['Shapes']
 
 
 def test_save_labels(make_napari_viewer, tmp_path: Path, test_data):
@@ -80,19 +80,19 @@ def test_save_labels(make_napari_viewer, tmp_path: Path, test_data):
     viewer.add_labels(
         test_labels
     )  # <- should add a way to specify this is the selected layer in the viewer
-    viewer.layers.selection.active = viewer.layers["test_labels"]
+    viewer.layers.selection.active = viewer.layers['test_labels']
     container = UtilitiesContainer(viewer)
 
     container._squeezed_dims = test_dims
     container._save_directory.value = tmp_path
-    container._save_name.value = "test.tiff"
+    container._save_name.value = 'test.tiff'
 
     labels = container.save_labels()
 
-    expected_save_loc = tmp_path / "Labels" / "test.tiff"
+    expected_save_loc = tmp_path / 'Labels' / 'test.tiff'
     assert expected_save_loc.exists()
     assert np.array_equal(labels, test_labels)
-    assert AICSImage(expected_save_loc).channel_names == ["Labels"]
+    assert AICSImage(expected_save_loc).channel_names == ['Labels']
 
 
 def test_save_ome_tiff(make_napari_viewer, test_data, tmp_path: Path):
@@ -103,14 +103,14 @@ def test_save_ome_tiff(make_napari_viewer, test_data, tmp_path: Path):
 
     container._concatenate_image_files.value = False
     container._concatenate_image_layers.value = True
-    container._viewer.layers.selection.active = viewer.layers["test_image"]
-    container._channel_names.value = ["0"]
+    container._viewer.layers.selection.active = viewer.layers['test_image']
+    container._channel_names.value = ['0']
     container._save_directory.value = tmp_path
-    container._save_name.value = "test.tiff"
+    container._save_name.value = 'test.tiff'
 
     container.save_ome_tiff()
 
-    expected_save_loc = tmp_path / "Images" / "test.tiff"
+    expected_save_loc = tmp_path / 'Images' / 'test.tiff'
     assert expected_save_loc.exists()
     assert len(container._img_data.shape) == 5
 
@@ -118,7 +118,7 @@ def test_save_ome_tiff(make_napari_viewer, test_data, tmp_path: Path):
 @pytest.fixture
 def test_rgb_image():
     path = os.path.join(
-        "src", "napari_ndev", "_tests", "resources", "RGB.tiff"
+        'src', 'napari_ndev', '_tests', 'resources', 'RGB.tiff'
     )
     img = AICSImage(path)
     return path, img
@@ -132,9 +132,9 @@ def test_update_metadata_from_file(make_napari_viewer, test_rgb_image):
     container._files.value = path
     container.update_metadata_from_file()
 
-    assert container._save_name.value == "RGB.tiff"
-    assert container._img.dims.order == "TCZYXS"
-    assert container._squeezed_dims == "YX"
+    assert container._save_name.value == 'RGB.tiff'
+    assert container._img.dims.order == 'TCZYXS'
+    assert container._squeezed_dims == 'YX'
     assert container._channel_names.value == "['red', 'green', 'blue']"
 
 
@@ -144,12 +144,12 @@ def test_update_metadata_from_layer(make_napari_viewer, test_data):
     viewer.add_image(test_image, scale=(2, 3))
     container = UtilitiesContainer(viewer)
 
-    container._viewer.layers.selection.active = viewer.layers["test_image"]
+    container._viewer.layers.selection.active = viewer.layers['test_image']
     container.update_metadata_from_layer()
 
     assert container._results.value == (
-        "Tried to update metadata, but could only update scale"
-        " because layer not opened with aicsimageio"
+        'Tried to update metadata, but could only update scale'
+        ' because layer not opened with aicsimageio'
     )
     assert container._scale_tuple.value == (1, 2, 3)
 

--- a/src/napari_ndev/_tests/test_workflow_container.py
+++ b/src/napari_ndev/_tests/test_workflow_container.py
@@ -12,19 +12,19 @@ def test_workflow_container_init(make_napari_viewer):
     assert container.viewer == viewer
     assert container.roots == []
     assert container._channel_names == []
-    assert container._img_dims == ""
+    assert container._img_dims == ''
 
 
 def test_workflow_container_update_root_choices(make_napari_viewer):
     viewer = make_napari_viewer()
     container = WorkflowContainer(viewer)
 
-    container._channel_names = ["red", "green", "blue"]
+    container._channel_names = ['red', 'green', 'blue']
 
     container._update_root_choices()
 
     for root in container.roots:
-        assert root.choices == ["red", "green", "blue"]
+        assert root.choices == ['red', 'green', 'blue']
 
 
 def test_workflow_container_update_roots(make_napari_viewer):
@@ -32,15 +32,15 @@ def test_workflow_container_update_roots(make_napari_viewer):
     container = WorkflowContainer(viewer)
 
     container.workflow = MockWorkflow()
-    container._channel_names = ["red", "green", "blue"]
+    container._channel_names = ['red', 'green', 'blue']
 
     container._update_roots()
 
     assert len(container.roots) == 2
 
     for idx, root in enumerate(container.roots):
-        assert root.label == f"Root {idx}: {container.workflow.roots()[idx]}"
-        assert root.choices == (None, "red", "green", "blue")
+        assert root.label == f'Root {idx}: {container.workflow.roots()[idx]}'
+        assert root.choices == (None, 'red', 'green', 'blue')
         assert root._nullable is True
         assert root.value is None
 
@@ -49,8 +49,8 @@ def test_workflow_container_get_workflow_info(make_napari_viewer):
     viewer = make_napari_viewer()
     container = WorkflowContainer(viewer)
     wf_path = pathlib.Path(
-        "src/napari_ndev/_tests/resources/Workflow/workflows/"
-        "test_2roots_1leaf.yaml"
+        'src/napari_ndev/_tests/resources/Workflow/workflows/'
+        'test_2roots_1leaf.yaml'
     )
     container.workflow_file.value = wf_path
 
@@ -60,10 +60,10 @@ def test_workflow_container_get_workflow_info(make_napari_viewer):
 
 class MockWorkflow:
     def roots(self):
-        return ["root1", "root2"]
+        return ['root1', 'root2']
 
     def leafs(self):
-        return ["leaf1", "leaf2"]
+        return ['leaf1', 'leaf2']
 
     def set(self, name, func_or_data):
         pass

--- a/src/napari_ndev/_utilities_container.py
+++ b/src/napari_ndev/_utilities_container.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import ast
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from magicgui.widgets import (
@@ -17,8 +19,9 @@ from magicgui.widgets import (
 from napari_ndev import helpers
 
 if TYPE_CHECKING:
-    import napari
     from aicsimageio import AICSImage
+
+    import napari
     from napari.layers import Image as ImageLayer
 
 
@@ -110,14 +113,13 @@ class UtilitiesContainer(Container):
 
     def __init__(
         self,
-        viewer: "napari.viewer.Viewer" = None,
+        viewer: napari.viewer.Viewer = None,
     ):
         super().__init__()
 
         ##############################
         # Attributes
         ##############################
-        self
         self._viewer = viewer if viewer is not None else None
         self._img_data = None
         self._image_save_dims = None
@@ -129,138 +131,138 @@ class UtilitiesContainer(Container):
         # Widgets
         ##############################
 
-        self._file_metadata_update = PushButton(label="File")
-        self._layer_metadata_update = PushButton(label="Selected Layer")
+        self._file_metadata_update = PushButton(label='File')
+        self._layer_metadata_update = PushButton(label='Selected Layer')
         self._metadata_container = Container(
-            layout="horizontal", label="Update Metadata from"
+            layout='horizontal', label='Update Metadata from'
         )
         self._metadata_container.append(self._layer_metadata_update)
         self._metadata_container.append(self._file_metadata_update)
 
         self._files = FileEdit(
-            label="File(s)",
-            mode="rm",
-            tooltip="Select file(s) to load.",
+            label='File(s)',
+            mode='rm',
+            tooltip='Select file(s) to load.',
         )
         self._open_image_update_metadata = CheckBox(
             value=True,
-            label="Update Metadata",
-            tooltip="Update metadata during initial file selection.",
+            label='Update Metadata',
+            tooltip='Update metadata during initial file selection.',
         )
-        self._open_image_button = PushButton(label="Open File(s)")
+        self._open_image_button = PushButton(label='Open File(s)')
         self._open_next_image_button = PushButton(
-            label="Open Next",
-            tooltip="Open the next file(s) in the directory. "
-            "The files are sorted alphabetically, which may not be consistent "
-            "with your file viewer. But, opening related consecutive files "
-            "should work as expected.",
+            label='Open Next',
+            tooltip='Open the next file(s) in the directory. '
+            'The files are sorted alphabetically, which may not be consistent '
+            'with your file viewer. But, opening related consecutive files '
+            'should work as expected.',
         )
 
-        self._open_image_container = Container(layout="horizontal")
+        self._open_image_container = Container(layout='horizontal')
         self._open_image_container.append(self._open_image_update_metadata)
         self._open_image_container.append(self._open_image_button)
         self._open_image_container.append(self._open_next_image_button)
 
         self._save_directory = FileEdit(
-            label="Save Directory",
-            mode="d",
-            tooltip="Directory where images will be saved.",
+            label='Save Directory',
+            mode='d',
+            tooltip='Directory where images will be saved.',
         )
         self._save_name = LineEdit(
-            label="File Save Name",
-            tooltip="Name of saved file. Helpful to include a"
-            ".ome/.tif/.tiff extension.",
+            label='File Save Name',
+            tooltip='Name of saved file. Helpful to include a'
+            '.ome/.tif/.tiff extension.',
         )
 
         self._dim_order = Label(
-            label="Dimension Order: ",
-            tooltip="Sanity check for available dimensions.",
+            label='Dimension Order: ',
+            tooltip='Sanity check for available dimensions.',
         )
         self._scenes = Label(
-            label="Number of Scenes: ",
+            label='Number of Scenes: ',
         )
-        self._info_container = Container(layout="horizontal")
+        self._info_container = Container(layout='horizontal')
         self._info_container.append(self._dim_order)
         self._info_container.append(self._scenes)
 
         self._channel_names = LineEdit(
-            label="Channel Name(s)",
-            tooltip="Enter channel names as a list. If left blank or the "
-            "channel names are not the proper length, then default channel "
-            "names will be used.",
+            label='Channel Name(s)',
+            tooltip='Enter channel names as a list. If left blank or the '
+            'channel names are not the proper length, then default channel '
+            'names will be used.',
         )
 
         self._scale_tuple = TupleEdit(
             value=(0.0000, 1.0000, 1.0000),
-            label="Scale, ZYX",
-            tooltip="Pixel size, usually in μm",
-            options={"step": 0.0001},
+            label='Scale, ZYX',
+            tooltip='Pixel size, usually in μm',
+            options={'step': 0.0001},
         )
         self._scale_layers = PushButton(
-            label="Scale Layer(s)",
-            tooltip="Scale the selected layer(s) based on the given scale.",
+            label='Scale Layer(s)',
+            tooltip='Scale the selected layer(s) based on the given scale.',
         )
         self._scale_container = Container(
-            layout="horizontal",
-            label="Scale Selected",
+            layout='horizontal',
+            label='Scale Selected',
         )
         self._scale_container.append(self._scale_layers)
 
         self._scenes_to_extract = LineEdit(
             # label="Scenes to Extract",
-            tooltip="Enter the scenes to extract as a list. If left blank "
-            "then all scenes will be extracted.",
+            tooltip='Enter the scenes to extract as a list. If left blank '
+            'then all scenes will be extracted.',
         )
         self._extract_scenes = PushButton(
-            label="Extract and Save Scenes",
-            tooltip="Extract scenes from a single selected file.",
+            label='Extract and Save Scenes',
+            tooltip='Extract scenes from a single selected file.',
         )
         self._scene_container = Container(
-            layout="horizontal",
-            label="Extract Scenes",
-            tooltip="Must be in list index format. Ex: [0, 1, 2] or [5:10]",
+            layout='horizontal',
+            label='Extract Scenes',
+            tooltip='Must be in list index format. Ex: [0, 1, 2] or [5:10]',
         )
         self._scene_container.append(self._scenes_to_extract)
         self._scene_container.append(self._extract_scenes)
 
         self._concatenate_image_files = CheckBox(
             value=True,
-            label="Concatenate Files",
-            tooltip="Concatenate files in the selected directory. Removes "
-            "blank channels.",
+            label='Concatenate Files',
+            tooltip='Concatenate files in the selected directory. Removes '
+            'blank channels.',
         )
         self._concatenate_image_layers = CheckBox(
-            label="Concatenate Image Layers",
-            tooltip="Concatenate image layers in the viewer. Removes empty.",
+            label='Concatenate Image Layers',
+            tooltip='Concatenate image layers in the viewer. Removes empty.',
         )
         self._concatenate_container = Container(
-            layout="horizontal",
-            label="Image Save Options",
+            layout='horizontal',
+            label='Image Save Options',
         )
         self._concatenate_container.append(self._concatenate_image_files)
         self._concatenate_container.append(self._concatenate_image_layers)
 
         self._save_image_button = PushButton(
-            label="Images",
-            tooltip="Save the concatenated image data as OME-TIFF.",
+            label='Images',
+            tooltip='Save the concatenated image data as OME-TIFF.',
         )
         self._save_labels_button = PushButton(
-            label="Labels", tooltip="Save the labels data as OME-TIFF."
+            label='Labels', tooltip='Save the labels data as OME-TIFF.'
         )
         self._save_shapes_button = PushButton(
-            label="Shapes as Labels",
-            tooltip="Save the shapes data as labels (OME-TIFF) according to "
-            "selected image layer dimensions.",
+            label='Shapes as Labels',
+            tooltip='Save the shapes data as labels (OME-TIFF) according to '
+            'selected image layer dimensions.',
         )
         self._save_container = Container(
-            layout="horizontal",
-            label="Save Selected Layers",
+            layout='horizontal',
+            label='Save Selected Layers',
         )
         self._save_container.append(self._save_image_button)
         self._save_container.append(self._save_labels_button)
         self._save_container.append(self._save_shapes_button)
 
-        self._results = TextEdit(label="Info")
+        self._results = TextEdit(label='Info')
 
         # Container Widget Order
         self.extend(
@@ -300,7 +302,7 @@ class UtilitiesContainer(Container):
         self._save_shapes_button.clicked.connect(self.save_shapes_as_labels)
         self._results._on_value_change()
 
-    def _update_metadata(self, img: "AICSImage"):
+    def _update_metadata(self, img: AICSImage):
         self._dim_order.value = img.dims.order
 
         self._squeezed_dims = helpers.get_squeezed_dim_order(img)
@@ -321,7 +323,7 @@ class UtilitiesContainer(Container):
         self._scenes.value = len(img.scenes)
 
     def update_metadata_from_file(self):
-        self._save_name.value = str(self._files.value[0].stem + ".tiff")
+        self._save_name.value = str(self._files.value[0].stem + '.tiff')
 
         if self._open_image_update_metadata.value:
             self._bioimage_metadata()
@@ -329,10 +331,10 @@ class UtilitiesContainer(Container):
     def update_metadata_from_layer(self):
         selected_layer = self._viewer.layers.selection.active
         try:
-            self._update_metadata(selected_layer.metadata["aicsimage"])
+            self._update_metadata(selected_layer.metadata['aicsimage'])
         except AttributeError:
             self._results.value = (
-                "Tried to update metadata, but no layer selected."
+                'Tried to update metadata, but no layer selected.'
             )
         except KeyError:
             scale = selected_layer.scale
@@ -342,12 +344,12 @@ class UtilitiesContainer(Container):
                 scale[-1],
             )
             self._results.value = (
-                "Tried to update metadata, but could only update scale"
-                " because layer not opened with aicsimageio"
+                'Tried to update metadata, but could only update scale'
+                ' because layer not opened with aicsimageio'
             )
 
     def open_images(self):
-        self._viewer.open(self._files.value, plugin="napari-aicsimageio")
+        self._viewer.open(self._files.value, plugin='napari-aicsimageio')
 
     def open_next_images(self):
         num_files = self._files.value.__len__()
@@ -355,18 +357,18 @@ class UtilitiesContainer(Container):
         first_file = self._files.value[0]
         parent_dir = first_file.parent
         # get the list of files in the parent directory
-        files = list(parent_dir.glob(f"*{first_file.suffix}"))
+        files = list(parent_dir.glob(f'*{first_file.suffix}'))
         # get the index of the first file in the list
         idx = files.index(first_file)
         # get the next file(s) in the list after the number of files
         next_files = files[idx + num_files : idx + num_files + num_files]
         # set the nwe save names, and update the file value
-        self._save_name.value = str(next_files[0].stem + ".tiff")
+        self._save_name.value = str(next_files[0].stem + '.tiff')
         self._files.value = next_files
         if self._open_image_update_metadata.value:
             self._bioimage_metadata()
 
-        self._viewer.open(next_files, plugin="napari-aicsimageio")
+        self._viewer.open(next_files, plugin='napari-aicsimageio')
 
     def rescale_by(self):
         layers = self._viewer.layers.selection
@@ -381,9 +383,9 @@ class UtilitiesContainer(Container):
     def concatenate_images(
         self,
         concatenate_files: bool,
-        files: List[Union[str, Path]],
+        files: list[str | Path],
         concatenate_layers: bool,
-        layers: List["ImageLayer"],
+        layers: list[ImageLayer],
     ):
         from aicsimageio import AICSImage
 
@@ -391,8 +393,8 @@ class UtilitiesContainer(Container):
         if concatenate_files:
             for file in files:
                 img = AICSImage(file)
-                if "S" in img.dims.order:
-                    img_data = img.get_image_data("TSZYX")
+                if 'S' in img.dims.order:
+                    img_data = img.get_image_data('TSZYX')
                 else:
                     img_data = img.data
 
@@ -433,7 +435,7 @@ class UtilitiesContainer(Container):
         data: np.ndarray,
         uri: Path,
         dim_order: str,
-        channel_names: List[str],
+        channel_names: list[str],
         layer: str,
     ) -> None:
         from aicsimageio.writers import OmeTiffWriter
@@ -454,7 +456,7 @@ class UtilitiesContainer(Container):
                 channel_names=channel_names or None,
                 physical_pixel_sizes=self.p_sizes,
             )
-            self._results.value = f"Saved {layer}: " + str(
+            self._results.value = f'Saved {layer}: ' + str(
                 self._save_name.value
             )
         # if ValueError is raised, save with default channel names
@@ -466,9 +468,9 @@ class UtilitiesContainer(Container):
                 physical_pixel_sizes=self.p_sizes,
             )
             self._results.value = (
-                "ValueError: "
+                'ValueError: '
                 + str(e)
-                + "\nSo, saved with default channel names: \n"
+                + '\nSo, saved with default channel names: \n'
                 + str(self._save_name.value)
             )
         return
@@ -479,7 +481,7 @@ class UtilitiesContainer(Container):
         img = AICSImage(self._files.value[0])
         scenes = self._scenes_to_extract.value
         scenes_list = ast.literal_eval(scenes) if scenes else None
-        save_directory = self._save_directory.value / "Images"
+        save_directory = self._save_directory.value / 'Images'
         save_directory.mkdir(parents=False, exist_ok=True)
         for scene in scenes_list:
             img.set_scene(scene)
@@ -497,9 +499,9 @@ class UtilitiesContainer(Container):
             self._common_save_logic(
                 data=img.data,
                 uri=img_save_loc,
-                dim_order="TCZYX",
+                dim_order='TCZYX',
                 channel_names=channel_names,
-                layer=f"Scene: {img.current_scene}",
+                layer=f'Scene: {img.current_scene}',
             )
         return
 
@@ -510,7 +512,7 @@ class UtilitiesContainer(Container):
             self._concatenate_image_layers.value,
             list(self._viewer.layers.selection),
         )
-        img_save_loc = self._get_save_loc("Images")
+        img_save_loc = self._get_save_loc('Images')
         # get channel names from widget if truthy
         cnames = self._channel_names.value
         channel_names = ast.literal_eval(cnames) if cnames else None
@@ -518,9 +520,9 @@ class UtilitiesContainer(Container):
         self._common_save_logic(
             data=self._img_data,
             uri=img_save_loc,
-            dim_order="TCZYX",
+            dim_order='TCZYX',
             channel_names=channel_names,
-            layer="Image",
+            layer='Image',
         )
         return self._img_data
 
@@ -532,14 +534,14 @@ class UtilitiesContainer(Container):
         else:
             label_data = label_data.astype(np.int16)
 
-        label_save_loc = self._get_save_loc("Labels")
+        label_save_loc = self._get_save_loc('Labels')
 
         self._common_save_logic(
             data=label_data,
             uri=label_save_loc,
             dim_order=self._squeezed_dims,
-            channel_names=["Labels"],
-            layer="Labels",
+            channel_names=['Labels'],
+            layer='Labels',
         )
         return label_data
 
@@ -559,14 +561,14 @@ class UtilitiesContainer(Container):
         shapes_as_labels = shapes.to_labels(labels_shape=label_dim)
         shapes_as_labels = shapes_as_labels.astype(np.int16)
 
-        shapes_save_loc = self._get_save_loc("ShapesAsLabels")
+        shapes_save_loc = self._get_save_loc('ShapesAsLabels')
 
         self._common_save_logic(
             data=shapes_as_labels,
             uri=shapes_save_loc,
             dim_order=self._squeezed_dims,
-            channel_names=["Shapes"],
-            layer="Shapes",
+            channel_names=['Shapes'],
+            layer='Shapes',
         )
 
         return shapes_as_labels

--- a/src/napari_ndev/_workflow_container.py
+++ b/src/napari_ndev/_workflow_container.py
@@ -64,38 +64,37 @@ class WorkflowContainer(Container):
         Signal emitted when the batch button is clicked.
     """
 
-    def __init__(self, viewer: "napari.viewer.Viewer"):
+    def __init__(self, viewer: 'napari.viewer.Viewer'):
         super().__init__()
         ##############################
         # Attributes
         ##############################
-        self
         self.viewer = viewer
         self.roots = []
         self._channel_names = []
-        self._img_dims = ""
+        self._img_dims = ''
 
         ##############################
         # Widgets
         ##############################
-        self.image_directory = FileEdit(label="Image Directory", mode="d")
-        self.result_directory = FileEdit(label="Result Directory", mode="d")
+        self.image_directory = FileEdit(label='Image Directory', mode='d')
+        self.result_directory = FileEdit(label='Result Directory', mode='d')
 
         self.workflow_file = FileEdit(
-            label="Workflow File",
-            filter="*.yaml",
-            tooltip="Select a workflow file to load",
+            label='Workflow File',
+            filter='*.yaml',
+            tooltip='Select a workflow file to load',
         )
         self._keep_original_images = CheckBox(
-            label="Keep Original Images",
+            label='Keep Original Images',
             value=False,
-            tooltip="If checked, the original images will be "
-            "concatenated with the results",
+            tooltip='If checked, the original images will be '
+            'concatenated with the results',
         )
-        self.batch_button = PushButton(label="Batch Workflow")
+        self.batch_button = PushButton(label='Batch Workflow')
 
-        self._progress_bar = ProgressBar(label="Progress:")
-        self._workflow_roots = Label(label="Workflow Roots:")
+        self._progress_bar = ProgressBar(label='Progress:')
+        self._workflow_roots = Label(label='Workflow Roots:')
 
         self.extend(
             [
@@ -143,7 +142,7 @@ class WorkflowContainer(Container):
 
         for idx, root in enumerate(self.workflow.roots()):
             root = ComboBox(
-                label=f"Root {idx}: {root}",
+                label=f'Root {idx}: {root}',
                 choices=self._channel_names,
                 nullable=True,
                 value=None,
@@ -175,33 +174,36 @@ class WorkflowContainer(Container):
         root_index_list = [self._channel_names.index(r) for r in root_list]
 
         # Setting up Logging File
-        log_loc = result_dir / "workflow.log.txt"
+        log_loc = result_dir / 'workflow.log.txt'
         logger, handler = helpers.setup_logger(log_loc)
         logger.info(
-            f"""
-        Image Directory: {self.image_directory.value}
-        Result Directory: {result_dir}
-        Workflow File: {self.workflow_file.value}
-        Roots: {root_list}
-        """
+            """
+            Image Directory: %s
+            Result Directory: %s
+            Workflow File: %s
+            Roots: %s
+            """,
+            self.image_directory.value,
+            result_dir,
+            self.workflow_file.value,
+            root_list,
         )
 
-        self._progress_bar.label = f"Workflow on {len(image_files)} images"
+        self._progress_bar.label = f'Workflow on {len(image_files)} images'
         self._progress_bar.value = 0
         self._progress_bar.max = len(image_files)
 
         for idx_file, image_file in enumerate(image_files):
-            logger.info(f"Processing {idx_file+1}: {image_file.name}")
+            logger.info('Processing %d: %s', idx_file+1, image_file.name)
             img = AICSImage(image_file)
 
             root_stack = []
             # get image corresponding to each root, and set it to the workflow
             for idx, root_index in enumerate(root_index_list):
-
-                if "S" in img.dims.order:
-                    root_img = img.get_image_data("TSZYX", S=root_index)
+                if 'S' in img.dims.order:
+                    root_img = img.get_image_data('TSZYX', S=root_index)
                 else:
-                    root_img = img.get_image_data("TCZYX", C=root_index)
+                    root_img = img.get_image_data('TCZYX', C=root_index)
                 # stack the TCZYX images for later stacking with results
                 root_stack.append(root_img)
                 # squeeze the root image for workflow
@@ -220,8 +222,8 @@ class WorkflowContainer(Container):
             # transform result_stack to TCZYX
             result_stack = transforms.reshape_data(
                 data=result_stack,
-                given_dims="C" + self._squeezed_img_dims,
-                return_dims="TCZYX",
+                given_dims='C' + self._squeezed_img_dims,
+                return_dims='TCZYX',
             )
 
             # <- should I add a check for the result_stack to be a dask array?
@@ -237,8 +239,8 @@ class WorkflowContainer(Container):
 
             OmeTiffWriter.save(
                 data=result_stack,
-                uri=result_dir / (image_file.stem + ".tiff"),
-                dim_order="TCZYX",
+                uri=result_dir / (image_file.stem + '.tiff'),
+                dim_order='TCZYX',
                 channel_names=result_names,
                 physical_pixel_sizes=img.physical_pixel_sizes,
             )

--- a/src/napari_ndev/image_overview.py
+++ b/src/napari_ndev/image_overview.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import stackview
 
@@ -6,7 +8,7 @@ def image_overview(
     image_sets: list[dict],
     xscale: float = 3,
     yscale: float = 3,
-    plot_title: str = "",
+    plot_title: str = '',
 ):
     """
     Create an overview of images.
@@ -26,7 +28,7 @@ def image_overview(
     """
     # create the subplot grid
     num_rows = len(image_sets)
-    num_columns = max([len(image_set["image"]) for image_set in image_sets])
+    num_columns = max([len(image_set['image']) for image_set in image_sets])
     fig, axs = plt.subplots(
         num_rows,
         num_columns,
@@ -40,19 +42,19 @@ def image_overview(
 
     # iterate through the image sets
     for row, image_set in enumerate(image_sets):
-        for col, image in enumerate(image_set["image"]):
+        for col, _image in enumerate(image_set['image']):
             # create a dictionary from the col-th values of each key
             image_dict = {key: value[col] for key, value in image_set.items()}
 
             # turn off the subplot and continue if there is no image
-            if image_dict.get("image") is None:
-                axs[row][col].axis("off")
+            if image_dict.get('image') is None:
+                axs[row][col].axis('off')
                 continue
 
             # create a labels key if it doesn't exist, but does in colormap
-            cmap = image_dict.get("colormap")
-            if cmap is not None and cmap.lower() == "labels":
-                image_dict["labels"] = True
+            cmap = image_dict.get('colormap')
+            if cmap is not None and cmap.lower() == 'labels':
+                image_dict['labels'] = True
 
             stackview.imshow(**image_dict, plot=axs[row][col])
 
@@ -80,7 +82,7 @@ class ImageOverview:
         image_sets: list[dict],
         xscale: float = 3,
         yscale: float = 3,
-        image_title: str = "",
+        image_title: str = '',
         show: bool = False,
     ):
         plt.ioff()
@@ -91,8 +93,8 @@ class ImageOverview:
 
     def save(
         self,
-        directory: str = None,
-        filename: str = None,
+        directory: str | None = None,
+        filename: str | None = None,
     ):
         """
         Save the generated image overview.
@@ -105,7 +107,7 @@ class ImageOverview:
         """
         import pathlib
 
-        dir = pathlib.Path(directory)
-        dir.mkdir(parents=True, exist_ok=True)
-        filepath = dir / filename
+        path_dir = pathlib.Path(directory)
+        path_dir.mkdir(parents=True, exist_ok=True)
+        filepath = path_dir / filename
         self.fig.savefig(filepath)

--- a/src/napari_ndev/measure.py
+++ b/src/napari_ndev/measure.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from bioio_base.types import ArrayLike, PathLike
 
-from napari_ndev import PlateMapper
+from napari_ndev._plate_mapper import PlateMapper
 
 
 def _convert_to_list(arg: list | ArrayLike | str | None):

--- a/src/napari_ndev/measure.py
+++ b/src/napari_ndev/measure.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import re
-from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -8,7 +9,7 @@ from bioio_base.types import ArrayLike, PathLike
 from napari_ndev import PlateMapper
 
 
-def _convert_to_list(arg: Union[List, ArrayLike, str, None]):
+def _convert_to_list(arg: list | ArrayLike | str | None):
     """convert any non-list arguments to lists"""
     if arg is None:
         return None
@@ -18,10 +19,10 @@ def _convert_to_list(arg: Union[List, ArrayLike, str, None]):
 
 
 def _generate_measure_dict(
-    label_images: Union[List[ArrayLike], ArrayLike],
-    label_names: Optional[Union[List[str], str]] = None,
-    intensity_images: Optional[Union[List[ArrayLike], ArrayLike]] = None,
-    intensity_names: Optional[Union[List[str], str]] = None,
+    label_images: list[ArrayLike] | ArrayLike,
+    label_names: list[str] | str | None = None,
+    intensity_images: list[ArrayLike] | ArrayLike | None = None,
+    intensity_names: list[str] | str | None = None,
 ) -> dict:
     """Generate a dictionary of label and intensity images with their names."""
     label_images = _convert_to_list(label_images)
@@ -31,17 +32,17 @@ def _generate_measure_dict(
 
     # automatically generate label and intensity names if not given
     if label_names is None:
-        label_names = [f"label_{i}" for i in range(len(label_images))]
+        label_names = [f'label_{i}' for i in range(len(label_images))]
     if intensity_names is None and intensity_images is not None:
         intensity_names = [
-            f"intensity_{i}" for i in range(len(intensity_images))
+            f'intensity_{i}' for i in range(len(intensity_images))
         ]
 
     return {
-        "label_images": label_images,
-        "label_names": label_names,
-        "intensity_images": intensity_images,
-        "intensity_names": intensity_names,
+        'label_images': label_images,
+        'label_names': label_names,
+        'intensity_images': intensity_images,
+        'intensity_names': intensity_names,
     }
 
 
@@ -66,7 +67,7 @@ def _extract_info_from_id_string(id_string: str, id_regex: dict) -> dict:
     return id_dict
 
 
-def _rename_intensity_columns(df: pd.DataFrame, intensity_names: List[str]):
+def _rename_intensity_columns(df: pd.DataFrame, intensity_names: list[str]):
     """
     Rename columns in the DataFrame to include the intensity names.
     The intensity names are appended to the end of the column name based
@@ -79,27 +80,25 @@ def _rename_intensity_columns(df: pd.DataFrame, intensity_names: List[str]):
     Returns:
     pd.DataFrame: The DataFrame with renamed columns.
     """
-    print(f"initial: {df.columns}")
 
     new_columns = []
     for col in df.columns:
-        if any(col.endswith(f"-{idx}") for idx in range(len(intensity_names))):
-            base_name, idx = col.rsplit("-", 1)
-            new_columns.append(f"{base_name}-{intensity_names[int(idx)]}")
+        if any(col.endswith(f'-{idx}') for idx in range(len(intensity_names))):
+            base_name, idx = col.rsplit('-', 1)
+            new_columns.append(f'{base_name}-{intensity_names[int(idx)]}')
         else:
             new_columns.append(col)
 
     df.columns = new_columns
 
-    print(f"renamed {df.columns}")
     return df
 
 
 def map_tx_dict_to_df_id_col(
-    tx: dict = None,
-    tx_n_well: int = None,
+    tx: dict | None = None,
+    tx_n_well: int | None = None,
     df: pd.DataFrame = None,
-    id_column: str = None,
+    id_column: str | None = None,
 ):
     """Map a dictionary of treatments to a dataframes id_column.
     This should work on either a complete dataset, or as part of an iterative
@@ -107,31 +106,31 @@ def map_tx_dict_to_df_id_col(
     if isinstance(tx_n_well, int):
         plate = PlateMapper(tx_n_well)
         plate.assign_treatments(tx)
-        tx_map = plate.plate_map.set_index("well_id").to_dict(orient="index")
+        tx_map = plate.plate_map.set_index('well_id').to_dict(orient='index')
     else:
         tx_map = tx
 
-    for id, txs in tx_map.items():
+    for identifier, txs in tx_map.items():
         for tx, condition in txs.items():
             if tx not in df.columns:
                 df[tx] = None
-            df.loc[df[id_column] == id, tx] = condition
+            df.loc[df[id_column] == identifier, tx] = condition
 
     return df
 
 
 def measure_regionprops(
-    label_images: Union[List[ArrayLike], ArrayLike],
-    label_names: Optional[Union[List[str], str]] = None,
-    intensity_images: Optional[Union[List[ArrayLike], ArrayLike]] = None,
-    intensity_names: Optional[Union[List[str], str]] = None,
-    properties: List[str] = ["area"],
-    scale: Union[Tuple[float, float], Tuple[float, float, float]] = (1, 1),
-    id_string: str = None,
-    id_regex_dict: Optional[dict] = None,
-    tx_id: Optional[str] = None,
-    tx_dict: Optional[dict] = None,
-    tx_n_well: Optional[int] = None,
+    label_images: list[ArrayLike] | ArrayLike,
+    label_names: list[str] | str | None = None,
+    intensity_images: list[ArrayLike] | ArrayLike | None = None,
+    intensity_names: list[str] | str | None = None,
+    properties: list[str] | None = None,
+    scale: tuple[float, float] | tuple[float, float, float] = (1, 1),
+    id_string: str | None = None,
+    id_regex_dict: dict | None = None,
+    tx_id: str | None = None,
+    tx_dict: dict | None = None,
+    tx_n_well: int | None = None,
     save_data_path: PathLike = None,
 ) -> pd.DataFrame:
     """Measure properties of labels with sci-kit image regionprops.
@@ -160,22 +159,24 @@ def measure_regionprops(
     """
     from skimage import measure
 
+    if properties is None:
+        properties = ['area']
     measure_dict = _generate_measure_dict(
         label_images, label_names, intensity_images, intensity_names
     )
 
     if intensity_images is not None:
-        if len(measure_dict["intensity_images"]) == 1:
-            intensity_stack = measure_dict["intensity_images"][0]
+        if len(measure_dict['intensity_images']) == 1:
+            intensity_stack = measure_dict['intensity_images'][0]
         else:
             intensity_stack = np.stack(
-                measure_dict["intensity_images"], axis=-1
+                measure_dict['intensity_images'], axis=-1
             )
     else:
         intensity_stack = None
 
     measure_props = measure.regionprops_table(
-        label_image=measure_dict["label_images"][0],
+        label_image=measure_dict['label_images'][0],
         intensity_image=intensity_stack,
         properties=properties,
         spacing=scale,
@@ -183,16 +184,14 @@ def measure_regionprops(
 
     measure_df = pd.DataFrame(measure_props)
 
-    print(f"initial: {measure_df.columns}")
 
     if intensity_names is not None:
         measure_df = _rename_intensity_columns(
-            measure_df, measure_dict["intensity_names"]
+            measure_df, measure_dict['intensity_names']
         )
 
-    print(f"renamed {measure_df.columns}")
 
-    measure_df.insert(0, "id", id_string)
+    measure_df.insert(0, 'id', id_string)
 
     if id_regex_dict is not None:
         id_dict = _extract_info_from_id_string(id_string, id_regex_dict)


### PR DESCRIPTION
- string double quotes to single
- isort imports
- from __future__ import annotations (delayed type checking)
  - removes strings from typing forward refs due to above
- removes f-strings from logs per G004
- renames variables away from python built-in names like dir and id
- remove useless self expressions (where did I get this idea from originally?)
- removes partial import of PlateMapper in measure
- all tests pass with pytest and tox on my machine