### PR TITLE
Clarify license and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,27 @@ A collection of widgets intended to serve any person seeking to process microsco
 pip install napari-ndev
 ```
 
-You may also like to install `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget.
+----------------------------------
+
+### Optional Libraries
+
+**napari-ndev** is most useful when interacting with some other napari plugins and can read additional filetypes. You may install these BSD-3 compatible plugins with [pip]:
 
 ```bash
-pip install napari-aicsimageio
+pip install napari-ndev[extras]
 ```
 
-In addition, you may need to install specific [`bioio` readers](https://github.com/bioio-devs/bioio) to support your specific image, such as `bioio-czi` or `bioio-lif`.
+**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget. These libraries can be installed with [pip]:
+
+```bash
+pip install napari-ndev[gpl-extras]
+```
+
+In addition, you may need to install specific [`bioio` readers](https://github.com/bioio-devs/bioio) to support your specific image, such as `bioio-czi` and `bioio-lif` (included in `[gpl-extras]`) or `bioio-bioformats`.
+
+### Development Libraries
+
+For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests.
 
 ----------------------------------
 
@@ -45,7 +59,9 @@ the coverage at least stays the same before you submit a pull request.
 ## License
 
 Distributed under the terms of the [BSD-3] license,
-"napari-ndev" is free and open source software
+"napari-ndev" is free and open source software.
+
+Some optional libraries can be installed to add functionality to `napari-ndev`, including some that may be more restrictive than this package's BSD-3-Clause.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ pip install napari-ndev
 
 ### Optional Libraries
 
-**napari-ndev** is most useful when interacting with some other napari plugins and can read additional filetypes. You may install these BSD-3 compatible plugins with [pip]:
+**napari-ndev** is most useful when interacting with some other napari plugins (e.g. napari-assistant) and can read additional filetypes (e.g. bioio-nd2). You may install these BSD-3 compatible plugins with [pip]:
 
 ```bash
 pip install napari-ndev[extras]
 ```
 
-**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget. These libraries can be installed with [pip]:
+**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget, but also adds support for `czi` and `lif` files. These libraries can be installed with [pip]:
 
 ```bash
 pip install napari-ndev[gpl-extras]

--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ pip install napari-ndev[extras]
 
 ```bash
 pip install napari-ndev[gpl-extras]
+
+or
+
+pip install napari-ndev[all]
 ```
 
 In addition, you may need to install specific [`bioio` readers](https://github.com/bioio-devs/bioio) to support your specific image, such as `bioio-czi` and `bioio-lif` (included in `[gpl-extras]`) or `bioio-bioformats`.
 
 ### Development Libraries
 
-For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests.
+For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests. You can also install `[dev-all]` to get all three of these dev dependencies.
 
 ----------------------------------
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-## Installation
+# Installation
 
 **napari-ndev** is a pure Python package, and can be installed with [pip]:
 
@@ -20,10 +20,14 @@ pip install napari-ndev[extras]
 
 ```bash
 pip install napari-ndev[gpl-extras]
+
+or
+
+pip install napari-ndev[all]
 ```
 
 In addition, you may need to install specific [`bioio` readers](https://github.com/bioio-devs/bioio) to support your specific image, such as `bioio-czi` and `bioio-lif` (included in `[gpl-extras]`) or `bioio-bioformats`.
 
 ### Development Libraries
 
-For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests.
+For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests. You can also install `[dev-all]` to get all three of these dev dependencies.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,15 +1,29 @@
-# Installation
+## Installation
 
-**napari-ndev** is a pure Python package, and can be installed with `pip`:
+**napari-ndev** is a pure Python package, and can be installed with [pip]:
 
 ```bash
 pip install napari-ndev
 ```
 
-You may also like to install `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget.
+----------------------------------
+
+### Optional Libraries
+
+**napari-ndev** is most useful when interacting with some other napari plugins (e.g. napari-assistant) and can read additional filetypes (e.g. bioio-nd2). You may install these BSD-3 compatible plugins with [pip]:
 
 ```bash
-pip install napari-aicsimageio
+pip install napari-ndev[extras]
 ```
 
-In addition, you may need to install specific [`bioio` readers](https://github.com/bioio-devs/bioio) to support your specific image, such as `bioio-czi` or `bioio-lif`.
+**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget. These libraries can be installed with [pip]:
+
+```bash
+pip install napari-ndev[gpl-extras]
+```
+
+In addition, you may need to install specific [`bioio` readers](https://github.com/bioio-devs/bioio) to support your specific image, such as `bioio-czi` and `bioio-lif` (included in `[gpl-extras]`) or `bioio-bioformats`.
+
+### Development Libraries
+
+For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests.

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ install_requires =
     bioio-ome-tiff
     bioio-imageio
     bioio-ome-zarr
-    bioio-nd2
     tifffile >= 2023.3.15 # https://github.com/AllenCellModeling/aicsimageio/issues/523
     scikit-image >= 0.18.0 # for multi-channel regionprops support
 
@@ -83,6 +82,7 @@ testing =
     napari-segment-blobs-and-things-with-membranes
 
 extras =
+    bioio-nd2
     napari-pyclesperanto-assistant
     napari-segment-blobs-and-things-with-membranes
     napari-simpleitk-image-processing
@@ -102,9 +102,19 @@ docs =
     mkdocs-spellcheck[all]
     mkdocs-literate-nav
     black
+
 dev =
     ruff
     pre-commit
+
+all =
+    napari-ndev[extras]
+    napari-ndev[gpl_extras]
+
+dev-all =
+    napari-ndev[testing]
+    napari-ndev[docs]
+    napari-ndev[dev]
 
 [options.package_data]
 * = *.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,8 @@ install_requires =
     bioio >= 1.1.0
     bioio-ome-tiff
     bioio-imageio
+    bioio-ome-zarr
+    bioio-nd2
     tifffile >= 2023.3.15 # https://github.com/AllenCellModeling/aicsimageio/issues/523
     scikit-image >= 0.18.0 # for multi-channel regionprops support
 
@@ -80,10 +82,15 @@ testing =
     pyqt5
     napari-segment-blobs-and-things-with-membranes
 
-extra-plugins =
+extras =
     napari-pyclesperanto-assistant
     napari-segment-blobs-and-things-with-membranes
     napari-simpleitk-image-processing
+
+gpl_extras =
+    napari-aicsimageio
+    bioio-czi
+    bioio-lif
 
 docs =
     mkdocs
@@ -94,8 +101,6 @@ docs =
     mkdocs-jupyter
     mkdocs-spellcheck[all]
     mkdocs-literate-nav
-    # mkdocs-gen-files
-    # mkdocs-section-index
     black
 dev =
     ruff


### PR DESCRIPTION
I have been attempting, on my own end, to clean up confusion with GPL3 and BSD-3 licenses. It would seem that BSD-3 is preferred in this field, and so I am trying to avoid requiring GPL3. However, many useful functionalities exist, like napari-aicsimageio, that I want to make easy for the user to install, when desired. This way, I can also add version control to these plugins as needed, as well. 