### PR TITLE
remove aicsimageio entirely switch to napari-bioio along with bioio changes

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -66,7 +66,7 @@ jobs:
           files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ A collection of widgets intended to serve any person seeking to process microsco
 pip install napari-ndev
 ```
 
+The easiest way to get started with **napari-ndev** is to install all the optional dependencies (see note below) with:
+
+```bash
+pip install napari-ndev[all]
+```
+
 ----------------------------------
 
 ### Optional Libraries
@@ -35,7 +41,7 @@ pip install napari-ndev
 pip install napari-ndev[extras]
 ```
 
-**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget, but also adds support for `czi` and `lif` files. These libraries can be installed with [pip]:
+**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-bioio` to properly handle metadata with the `Image Utilities` widget, but also adds support for `czi` and `lif` files. These libraries can be installed with [pip]:
 
 ```bash
 pip install napari-ndev[gpl-extras]

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 
 A collection of widgets intended to serve any person seeking to process microscopy images from start to finish. The wide breadth of this plugin's scope is only made possible by the amazing libraries and plugins from the napari community, especially Robert Haase. Currently, the plugin supports the following goals:
 
-1. **Image Utilities:** Intended for high-throuput image-labeling and management, while passing down important metadata. Allows opening image files (preferably with `napari-aicsimageio` see [Installation](installation.md)) and displaying in napari. Also reads metadata and allows customization prior to saving images and labels layers. Allows concatenation of image files and image layers for saving new images. Speeds up annotation by saving corresponding images and labels in designated folders. Also allows saving of shapes layers as labels in case shapes are being used as a region of interest.
+1. **Image Utilities:** Intended for high-throuput image-labeling and management, while passing down important metadata. Allows opening image files (preferably with `napari-bioimageio` see [Installation](installation.md)) and displaying in napari. Also reads metadata and allows customization prior to saving images and labels layers. Allows concatenation of image files and image layers for saving new images. Speeds up annotation by saving corresponding images and labels in designated folders. Also allows saving of shapes layers as labels in case shapes are being used as a region of interest.
 2. **Workflow Widget:** Batch pre-processing/processing images using [napari-workflows].
 3. **APOC Widget:** Utilizes the excellent accelerated-pixel-and-object-classification ([apoc]) in a similar fashion to [napari-apoc], but intended for batch training and prediction with a napari widget instead of scripting.
     * **Custom Feature Set Widget:** Generate a featureset to be used with the APOC widget. Also allows quick application in the napari viewer to an image layer to see all the features.
@@ -24,13 +24,13 @@ A collection of widgets intended to serve any person seeking to process microsco
 
 ### 1. Image Utilities
 
-A quick and easy way to save annotations (a napari labels layer) and corresponding images to corresponding folders. Best if the images are opened with [napari-aicsimageio]--which can be as simple as drag and drop opening by setting the appropriate default reader for each file type in Preferences -> Plugins--in order to utilize the metadata present for saving the image-label pairs. (See [Note about bioio/AICSImageIO](#a-note-about-bioioaicsimageio))
+A quick and easy way to save annotations (a napari labels layer) and corresponding images to corresponding folders. Best if the images are opened with [napari-bioio]--which can be as simple as drag and drop opening by setting the appropriate default reader for each file type in Preferences -> Plugins--in order to utilize the metadata present for saving the image-label pairs.
 
-Quick uniform adjustments to a folder of images, saving the output. Currently supports selecting channels, slicing Z, cropping/downsampling in XY, and doing a max projection of the sliced/cropped image data. To be added: alternative projection types, slicing in T, and compatibility with non TCZYX images (but this is not a priority since [bioio] and [aicsimageio] currently always extracts images as TCZYX even if a dim is only length 1.
+Quick uniform adjustments to a folder of images, saving the output. Currently supports selecting channels, slicing Z, cropping/downsampling in XY, and doing a max projection of the sliced/cropped image data. To be added: alternative projection types, slicing in T, and compatibility with non TCZYX images (but this is not a priority since [bioio] currently always extracts images as TCZYX even if a dim is only length 1.
 
 ### 2. Workflow Widget
 
-Batch pre-processing/processing images using [napari-workflows].  Images are processed outside the napari-viewer using [aicsimageio] as both reader and writer. Prior to passing the images to napari-workflows, the user selects the correct images as the roots (inputs) and thus napari-workflows matches the processing to create the outputs. The advantage of using napari-workflows for batch processing is that it provides an incredibly flexible processing interface without writing a novel widget for small changes to processing steps like specific filters, segmentation, or measurements. Currently only intended for use with images as inputs and images as outputs from napari-workflows, though there is future potential to have other outputs possible, such as .csv measurement arrays.
+Batch pre-processing/processing images using [napari-workflows].  Images are processed outside the napari-viewer using [bioio] as both reader and writer. Prior to passing the images to napari-workflows, the user selects the correct images as the roots (inputs) and thus napari-workflows matches the processing to create the outputs. The advantage of using napari-workflows for batch processing is that it provides an incredibly flexible processing interface without writing a novel widget for small changes to processing steps like specific filters, segmentation, or measurements. Currently only intended for use with images as inputs and images as outputs from napari-workflows, though there is future potential to have other outputs possible, such as .csv measurement arrays.
 
 ### 3. APOC Widget
 
@@ -40,18 +40,11 @@ Utilizes the excellent accelerated-pixel-and-object-classification ([apoc]) in a
 
 Batch measurements using [scikit-image]'s [regionprops]. This can measure features of a label such as area, eccentricity, and more but also can measure various intensity metrics. Attempts to support post-processing of measurements, grouping, and more to make downstream analyses easier for users. Will be updated in the future to include [nyxus].
 
-### A Note about bioio/AICSImageIO
-
-[AICSImageIO] is a convenient, multi-format file reader which also has the complimentary [napari-aicsimageio] reader plugin. However, the codebase is currently being switched over to [bioio] as the package matures; bioio is a replacement for AICSImageIO and will have less issues with compatibilities.
-
-By default, napari-aicsimageio installs all reader dependencies. Because napari-aicsimageio is not technically required for this plugin to work (you could build your own metadata for the annotation-saver) and just napari is required, the former is not an install requirement. This is to avoid using the GPL licence and to stick with BSD-3. However, you should install napari-aicsimageio if you want the smoothest operation of the widgets.
-
 [napari-workflows]: https://github.com/haesleinhuepf/napari-workflows
 [apoc]: https://github.com/haesleinhuepf/apoc
 [napari-apoc]: https://github.com/haesleinhuepf/napari-accelerated-pixel-and-object-classification
-[napari-aicsimageio]: https://github.com/AllenCellModeling/napari-aicsimageio
+[napari-bioio]: https://github.com/TimMonko/napari-bioio
 [bioio]: https://github.com/bioio-devs/bioio
-[AICSImageIO]: https://allencellmodeling.github.io/aicsimageio/
 [scikit-image]: https://scikit-image.org/
 [regionprops]: https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.regionprops
 [nyxus]: https://github.com/PolusAI/nyxus

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ pip install napari-ndev
 pip install napari-ndev[extras]
 ```
 
-**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-aicsimageio` to properly handle metadata with the `Image Utilities` widget. These libraries can be installed with [pip]:
+**napari-ndev** can optionally use GPL-3 licensed libraries to enhance its functionality, but are not required. If you choose to install and use these optional dependencies, you must comply with the GPL-3 license terms. The main functional improvement is from `napari-bioio` to properly handle metadata with the `Image Utilities` widget. These libraries can be installed with [pip]:
 
 ```bash
 pip install napari-ndev[gpl-extras]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,11 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy >= 1.26 # required for python 3.12 to build
-    siphash24 >= 1.6
+    numpy >= 1.26, < 2.0 # for python 3.12 compatibility
+    siphash24 >= 1.6 # to prevent fallback to python's hash function
     magicgui >= 0.8.3
-    qtpy
-    aicsimageio
-    napari[all] >= 0.4.19
+    magic-class
+    napari[all] >= 0.4.19 # for proper interaction with scaled images
     apoc
     pyclesperanto-prototype
     dask
@@ -80,6 +79,7 @@ testing =
     napari
     pyqt5
     napari-segment-blobs-and-things-with-membranes
+    napari-bioio @ git+https://github.com/TimMonko/napari-bioio.git@main#egg=napari-bioio
 
 extras =
     bioio-nd2
@@ -88,9 +88,9 @@ extras =
     napari-simpleitk-image-processing
 
 gpl_extras =
-    napari-aicsimageio
-    bioio-czi
+    bioio-czi >= 1.0.1
     bioio-lif
+    napari-bioio @ git+https://github.com/TimMonko/napari-bioio.git@main#egg=napari-bioio
 
 docs =
     mkdocs

--- a/src/napari_ndev/_tests/test_helpers.py
+++ b/src/napari_ndev/_tests/test_helpers.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from aicsimageio import AICSImage
 from bioio import BioImage
 from bioio.writers import OmeTiffWriter
 
@@ -123,7 +122,7 @@ def test_get_channel_names_CYX():
 
 def test_get_channel_names_RGB():
     file = Path(r'./src/napari_ndev/_tests/resources/RGB.tiff')
-    img = AICSImage(file)
+    img = BioImage(file)
     assert get_channel_names(img) == ['red', 'green', 'blue']
 
 
@@ -165,7 +164,7 @@ def test_get_squeezed_dim_order_ZYX():
 
 def test_get_squeezed_dim_order_RGB():
     file = Path(r'./src/napari_ndev/_tests/resources/RGB.tiff')
-    img = AICSImage(file)
+    img = BioImage(file)
     assert get_squeezed_dim_order(img) == 'YX'
 
 

--- a/src/napari_ndev/_tests/widgets/test_apoc_container.py
+++ b/src/napari_ndev/_tests/widgets/test_apoc_container.py
@@ -215,9 +215,9 @@ def test_update_metadata_from_file():
             ['/path/to/file.tif'],
         )
 
-        # Mock the AICSImage class to return sample channel names
-        with patch('aicsimageio.AICSImage') as mock_AICSImage:
-            mock_AICSImage.return_value.channel_names = ['C0', 'C1', 'C2']
+        # Mock the BioImage class to return sample channel names
+        with patch('bioio.BioImage') as mock_BioImage:
+            mock_BioImage.return_value.channel_names = ['C0', 'C1', 'C2']
 
             # Call the _update_metadata_from_file method
             wdg._update_metadata_from_file()

--- a/src/napari_ndev/_tests/widgets/test_apoc_container.py
+++ b/src/napari_ndev/_tests/widgets/test_apoc_container.py
@@ -216,8 +216,8 @@ def test_update_metadata_from_file():
         )
 
         # Mock the BioImage class to return sample channel names
-        with patch('bioio.BioImage') as mock_BioImage:
-            mock_BioImage.return_value.channel_names = ['C0', 'C1', 'C2']
+        with patch('bioio.BioImage') as BioImage:
+            BioImage.return_value.channel_names = ['C0', 'C1', 'C2']
 
             # Call the _update_metadata_from_file method
             wdg._update_metadata_from_file()

--- a/src/napari_ndev/_tests/widgets/test_utilities_container.py
+++ b/src/napari_ndev/_tests/widgets/test_utilities_container.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from aicsimageio import AICSImage
+from bioio import BioImage
 
 from napari_ndev.widgets._utilities_container import UtilitiesContainer
 
@@ -70,7 +70,7 @@ def test_save_shapes_as_labels(
     assert expected_save_loc.exists()
     assert shapes_as_labels.shape == test_image.shape
     assert np.array_equal(shapes_as_labels, test_labels)
-    assert AICSImage(expected_save_loc).channel_names == ['Shapes']
+    assert BioImage(expected_save_loc).channel_names == ['Shapes']
 
 
 def test_save_labels(make_napari_viewer, tmp_path: Path, test_data):
@@ -92,7 +92,7 @@ def test_save_labels(make_napari_viewer, tmp_path: Path, test_data):
     expected_save_loc = tmp_path / 'Labels' / 'test.tiff'
     assert expected_save_loc.exists()
     assert np.array_equal(labels, test_labels)
-    assert AICSImage(expected_save_loc).channel_names == ['Labels']
+    assert BioImage(expected_save_loc).channel_names == ['Labels']
 
 
 def test_save_ome_tiff(make_napari_viewer, test_data, tmp_path: Path):
@@ -120,7 +120,7 @@ def test_rgb_image():
     path = os.path.join(
         'src', 'napari_ndev', '_tests', 'resources', 'RGB.tiff'
     )
-    img = AICSImage(path)
+    img = BioImage(path)
     return path, img
 
 
@@ -149,20 +149,18 @@ def test_update_metadata_from_layer(make_napari_viewer, test_data):
 
     assert (
         'Tried to update metadata, but could only update scale'
-        ' because layer not opened with aicsimageio'
+        ' because layer not opened with napari-bioio'
     ) in container._results.value
     assert container._scale_tuple.value == (1, 2, 3)
 
+def test_open_images(make_napari_viewer, test_rgb_image):
+    viewer = make_napari_viewer()
+    container = UtilitiesContainer(viewer)
 
-# failing tox because no napari-aicsimageio in requirements
-# def test_open_images(make_napari_viewer, test_rgb_image):
-#     viewer = make_napari_viewer()
-#     container = UtilitiesContainer(viewer)
+    path, _ = test_rgb_image
+    container._files.value = path
+    container.open_images()
 
-#     path, _ = test_rgb_image
-#     container._files.value = path
-#     container.open_images()
-
-#     assert container._img.dims.order == "TCZYXS"
-#     assert container._squeezed_dims == "YX"
-#     assert container._channel_names.value == "['red', 'green', 'blue']"
+    assert container._img.dims.order == "TCZYXS"
+    assert container._squeezed_dims == "YX"
+    assert container._channel_names.value == "['red', 'green', 'blue']"

--- a/src/napari_ndev/helpers.py
+++ b/src/napari_ndev/helpers.py
@@ -4,8 +4,8 @@ Helper functions for file handling, image processing, and logging setup.
 Functions
 ---------
 get_directory_and_files : Get the directory and files in the specified directory.
-get_channel_names : Get the channel names from an AICSImage or BioImage object.
-get_squeezed_dim_order : Return a string containing the squeezed dimensions of the given AICSImage or BioImage object.
+get_channel_names : Get the channel names from an BioImage object.
+get_squeezed_dim_order : Return a string containing the squeezed dimensions of the given BioImage object.
 create_id_string : Create an ID string for the given image.
 check_for_missing_files : Check if the given files are missing in the specified directories.
 setup_logger : Set up a logger with the specified log location.
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from aicsimageio import AICSImage
     from bioio import BioImage
 
 __all__ = [
@@ -32,12 +31,11 @@ __all__ = [
     'setup_logger',
 ]
 
-def get_Image(file: str | Path) -> AICSImage | BioImage:
+def get_Image(file: str | Path) -> BioImage:
     """
-    Read the image file with BioImage or AICSImage.
+    Read the image file with BioImage.
 
-    Open the image file with BioImage, or if the file is not supported,
-    open it with AICSImage.
+    Open the image file with BioImage.
 
     Parameters
     ----------
@@ -46,7 +44,7 @@ def get_Image(file: str | Path) -> AICSImage | BioImage:
 
     Returns
     -------
-    AICSImage or BioImage
+    BioImage
         The image object.
 
     """
@@ -56,8 +54,7 @@ def get_Image(file: str | Path) -> AICSImage | BioImage:
     try:
         img = BioImage(file)
     except UnsupportedFileFormatError:
-        from aicsimageio import AICSImage
-        img = AICSImage(file)
+        raise UnsupportedFileFormatError(f'Unsupported file format: {file}') from None
     return img
 
 
@@ -122,9 +119,9 @@ def get_directory_and_files(
     return directory, files
 
 
-def get_channel_names(img: AICSImage | BioImage) -> list[str]:
+def get_channel_names(img: BioImage) -> list[str]:
     """
-    Get the channel names from an AICSImage object.
+    Get the channel names from a BioImage object.
 
     If the image has a dimension order that includes "S" (it is RGB),
     return the default channel names ["red", "green", "blue"].
@@ -132,8 +129,8 @@ def get_channel_names(img: AICSImage | BioImage) -> list[str]:
 
     Parameters
     ----------
-    img : AICSImage or BioImage
-        The AICSImage object.
+    img : BioImage
+        The BioImage object.
 
     Returns
     -------
@@ -147,16 +144,16 @@ def get_channel_names(img: AICSImage | BioImage) -> list[str]:
 
 
 def get_squeezed_dim_order(
-    img: AICSImage | BioImage,
+    img: BioImage,
     skip_dims: list[str] | str | None = None,
 ) -> str:
     """
-    Return a string containing the squeezed dimensions of the given AICSImage object.
+    Return a string containing the squeezed dimensions of the given BioImage.
 
     Parameters
     ----------
-    img : AICSImage or BioImage
-        The AICSImage object.
+    img : BioImage
+        The BioImage object.
     skip_dims : list of str or str or None, optional
         Dimensions to skip. Defaults to ["C", "S"].
 
@@ -173,13 +170,13 @@ def get_squeezed_dim_order(
     )
 
 
-def create_id_string(img: BioImage | AICSImage, identifier: str) -> str:
+def create_id_string(img: BioImage, identifier: str) -> str:
     """
     Create an ID string for the given image.
 
     Parameters
     ----------
-    img : BioImage or AICSImage
+    img : BioImage
         The image object.
     identifier : str
         The identifier string.

--- a/src/napari_ndev/helpers.py
+++ b/src/napari_ndev/helpers.py
@@ -49,13 +49,8 @@ def get_Image(file: str | Path) -> BioImage:
 
     """
     from bioio import BioImage
-    from bioio_base.exceptions import UnsupportedFileFormatError
 
-    try:
-        img = BioImage(file)
-    except UnsupportedFileFormatError:
-        raise UnsupportedFileFormatError(f'Unsupported file format: {file}') from None
-    return img
+    return BioImage(file)
 
 
 def get_directory_and_files(

--- a/src/napari_ndev/widgets/_apoc_container.py
+++ b/src/napari_ndev/widgets/_apoc_container.py
@@ -370,10 +370,10 @@ class ApocContainer(Container):
         self._image_layers.choices = self._filter_layers(layers.Image)
 
     def _update_metadata_from_file(self):
-        from aicsimageio import AICSImage
+        from bioio import BioImage
 
         _, files = helpers.get_directory_and_files(self._image_directory.value)
-        img = AICSImage(files[0])
+        img = BioImage(files[0])
         self._image_channels.choices = helpers.get_channel_names(img)
 
     def _update_channel_order(self):
@@ -490,7 +490,7 @@ class ApocContainer(Container):
         return channel_img
 
     def batch_train(self):
-        from aicsimageio import AICSImage
+        from bioio import BioImage
 
         image_directory, image_files = helpers.get_directory_and_files(
             self._image_directory.value
@@ -550,10 +550,10 @@ class ApocContainer(Container):
 
             logger.info('Training Image %d: %s', idx + 1, image_file.name)
 
-            img = AICSImage(image_directory / image_file.name)
+            img = BioImage(image_directory / image_file.name)
             channel_img = self._get_channel_image(img, channel_index_list)
 
-            lbl = AICSImage(label_directory / image_file.name)
+            lbl = BioImage(label_directory / image_file.name)
             label = lbl.get_image_data('TCZYX', C=0)
 
             # <- this is where setting up dask processing would be useful
@@ -586,8 +586,8 @@ class ApocContainer(Container):
         return None
 
     def batch_predict(self):
-        from aicsimageio import AICSImage
-        from aicsimageio.writers import OmeTiffWriter
+        from bioio import BioImage
+        from bioio.writers import OmeTiffWriter
 
         image_directory, image_files = helpers.get_directory_and_files(
             dir_path=self._image_directory.value,
@@ -628,7 +628,7 @@ class ApocContainer(Container):
         for idx, file in enumerate(image_files):
             logger.info('Predicting Image %d: %s', idx + 1, file.name)
 
-            img = AICSImage(file)
+            img = BioImage(file)
             channel_img = self._get_channel_image(img, channel_index_list)
             squeezed_dim_order = helpers.get_squeezed_dim_order(img)
 


### PR DESCRIPTION
all other relavent updates were made to my main fork of napari-bioio
removes every use of aicsimageio or napari-aicsimageio, now uses the custom napari-bioio until that plugin is re-released