### PR TITLE
Add tox testing for macos

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,windows}
-; envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{39,310,311,312}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
@@ -14,13 +13,13 @@ python =
 [gh-actions:env]
 PLATFORM =
     ubuntu-latest: linux
-    ; macos-latest: macos
+    macos-latest: macos
     windows-latest: windows
 
 [testenv]
 platform =
     linux: linux
-    ; macos: darwin
+    macos: darwin
     windows: win32
 passenv =
     CI


### PR DESCRIPTION
Macos testing was previously commented out. I'm starting out by not knowing why, and will make a pull request to find the errors. 