### PR TITLE
lazy import all gpu-dependent funs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,12 @@ multiline-quotes = "double"
 ban-relative-imports = "all"
 
 
+[tool.ruff.lint.flake8-tidy-imports.banned-modules] # disallow gpu-dependent top level imports
+pyclesperanto = "Importing 'pyclesperanto' top-level is not allowed."
+pyclesperanto_prototype = "Importing 'pyclesperanto_prototype' top-level is not allowed."
+apoc = "Importing 'apoc' top-level is not allowed."
+
+
 [tool.ruff.lint.isort]
 known-first-party=['napari']
 combine-as-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ multiline-quotes = "double"
 ban-relative-imports = "all"
 
 
-[tool.ruff.lint.flake8-tidy-imports.banned-modules] # disallow gpu-dependent top level imports
+[tool.ruff.lint.flake8-tidy-imports.banned-module-level-imports] # disallow gpu-dependent top level imports
 pyclesperanto = "Importing 'pyclesperanto' top-level is not allowed."
 pyclesperanto_prototype = "Importing 'pyclesperanto_prototype' top-level is not allowed."
 apoc = "Importing 'apoc' top-level is not allowed."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,12 +97,7 @@ multiline-quotes = "double"
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
-
-
-[tool.ruff.lint.flake8-tidy-imports.banned-module-level-imports] # disallow gpu-dependent top level imports
-pyclesperanto = "Importing 'pyclesperanto' top-level is not allowed."
-pyclesperanto_prototype = "Importing 'pyclesperanto_prototype' top-level is not allowed."
-apoc = "Importing 'apoc' top-level is not allowed."
+banned-module-level-imports = ["pyclesperanto", "pyclesperanto_prototype", "apoc"]
 
 
 [tool.ruff.lint.isort]

--- a/src/napari_ndev/_tests/test_morphology.py
+++ b/src/napari_ndev/_tests/test_morphology.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pyclesperanto_prototype as cle
 import pytest
 
 from napari_ndev import morphology
@@ -30,6 +29,7 @@ def test_skeletonize_labels():
 
 @pytest.mark.notox
 def test_connect_breaks_between_labels():
+    import pyclesperanto_prototype as cle
     """Test the connect_breaks_between_labels function."""
     connect_distance = 1.5
     connected_labels = morphology.connect_breaks_between_labels(label_2d, connect_distance)
@@ -40,6 +40,7 @@ def test_connect_breaks_between_labels():
 
 @pytest.mark.notox
 def test_label_voronoi_based_on_intensity():
+    import pyclesperanto_prototype as cle
     """Test the label_voronoi_based_on_intensity function."""
     image = np.array([[10, 0, 1, 1], [0, 0, 1, 1], [1, 2, 1, 1], [2, 2, 10, 1]])
     labels = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]])

--- a/src/napari_ndev/_tests/widgets/test_apoc_container.py
+++ b/src/napari_ndev/_tests/widgets/test_apoc_container.py
@@ -5,7 +5,6 @@ import tempfile
 from unittest.mock import patch
 
 import numpy as np
-import pyclesperanto_prototype as cle
 import pytest
 
 from napari_ndev.widgets._apoc_container import ApocContainer
@@ -155,6 +154,7 @@ def trained_classifier_file(
 
 @pytest.mark.notox
 def test_image_predict(make_napari_viewer, test_data, trained_classifier_file):
+    import pyclesperanto_prototype as cle
     viewer = make_napari_viewer()
     test_image, _, _, _ = test_data
     viewer.add_image(test_image)

--- a/src/napari_ndev/morphology.py
+++ b/src/napari_ndev/morphology.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-import pyclesperanto_prototype as cle
 
 if TYPE_CHECKING:
     from bioio_base.types import ArrayLike
@@ -60,6 +59,7 @@ def skeletonize_labels(label: ArrayLike) -> np.ndarray:
 
     """
     from skimage.morphology import skeletonize
+    import pyclesperanto_prototype as cle
 
     skeleton = skeletonize(cle.pull(label))
     return (label * skeleton).astype(np.uint16)
@@ -87,6 +87,8 @@ def connect_breaks_between_labels(label: ArrayLike, connect_distance: float) -> 
         Label image with new labels connecting breaks between original labels.
 
     """
+    import pyclesperanto_prototype as cle
+    
     label_dilated = cle.dilate_labels(label, radius=connect_distance/2)
     label_merged = cle.merge_touching_labels(label_dilated)
     # relabel original labels based on the merged labels
@@ -114,6 +116,8 @@ def label_voronoi_based_on_intensity(label: ArrayLike, intensity_image: ArrayLik
         Label image with Voronoi regions based on the intensity image.
 
     """
+    import pyclesperanto_prototype as cle
+
     label_binary = cle.greater_constant(label, constant=0) # binarize
     intensity_blur = cle.gaussian_blur(intensity_image, sigma_x=1, sigma_y=1)
     intensity_peaks = cle.detect_maxima_box(intensity_blur, radius_x=0, radius_y=0)

--- a/src/napari_ndev/morphology.py
+++ b/src/napari_ndev/morphology.py
@@ -58,8 +58,8 @@ def skeletonize_labels(label: ArrayLike) -> np.ndarray:
         Skeletonized label image.
 
     """
-    from skimage.morphology import skeletonize
     import pyclesperanto_prototype as cle
+    from skimage.morphology import skeletonize
 
     skeleton = skeletonize(cle.pull(label))
     return (label * skeleton).astype(np.uint16)
@@ -88,7 +88,7 @@ def connect_breaks_between_labels(label: ArrayLike, connect_distance: float) -> 
 
     """
     import pyclesperanto_prototype as cle
-    
+
     label_dilated = cle.dilate_labels(label, radius=connect_distance/2)
     label_merged = cle.merge_touching_labels(label_dilated)
     # relabel original labels based on the merged labels

--- a/src/napari_ndev/widgets/_apoc_container.py
+++ b/src/napari_ndev/widgets/_apoc_container.py
@@ -21,7 +21,6 @@ from magicgui.widgets import (
     SpinBox,
     Table,
 )
-from pyclesperanto_prototype import set_wait_for_kernel_finish
 from qtpy.QtWidgets import QTabWidget
 
 from napari import layers
@@ -491,6 +490,7 @@ class ApocContainer(Container):
 
     def batch_train(self):
         from bioio import BioImage
+        from pyclesperanto_prototype import set_wait_for_kernel_finish
 
         image_directory, image_files = helpers.get_directory_and_files(
             self._image_directory.value
@@ -588,6 +588,7 @@ class ApocContainer(Container):
     def batch_predict(self):
         from bioio import BioImage
         from bioio.writers import OmeTiffWriter
+        from pyclesperanto_prototype import set_wait_for_kernel_finish
 
         image_directory, image_files = helpers.get_directory_and_files(
             dir_path=self._image_directory.value,
@@ -664,6 +665,7 @@ class ApocContainer(Container):
         logger.removeHandler(handler)
 
     def image_train(self):
+        from pyclesperanto_prototype import set_wait_for_kernel_finish
         image_names = [image.name for image in self._image_layers.value]
         label_name = self._label_layer.value.name
         self._single_result_label.value = (
@@ -695,6 +697,7 @@ class ApocContainer(Container):
         )
 
     def image_predict(self):
+        from pyclesperanto_prototype import set_wait_for_kernel_finish
         set_wait_for_kernel_finish(
             True
         )  # https://github.com/clEsperanto/pyclesperanto_prototype/issues/163


### PR DESCRIPTION
Pull request forces all gpu-dependent modules to not be top-level imports.

This does resolve immediate issues with clesperanto trying to find the correct device. Oddly, known of the functions which get pyclesperanto._core called are from pyclesperanto but instead from pyclesperanto_prototype.

Now, test_skeletonize_labels is the first instance of calling into clesperanto. However, it is only required for cle.pull of a numpy array. Therefore, the test may pass because it doesn't actually require an opencl backend. Keep an eye on this, may be a source of tests failing int he future, and I can definitely clean up the implementation of functions that don't *require* the gpu, and is just used for convenience. Probably better to use np.asarray instead... 