### PR TITLE
Pin `ngff-zarr<0.10.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     tifffile >= 2023.3.15 # https://github.com/AllenCellModeling/aicsimageio/issues/523 maybe keep for legacy reasons?
     scikit-image >= 0.18.0 # 0.18.0 for multi-channel regionprops support
     # bioio BSD3 dependencies
+    ngff-zarr < 0.10.0 # 0.10.0 changes zarr_metadata module to v04.zarr_metadata module, breaking bioio.ome_tiff_writer
     bioio >= 1.1.0
     bioio-ome-tiff >= 1
     bioio-tifffile >= 1


### PR DESCRIPTION
Update to `ngff-zarr` 0.10.0 changes name of `zarr_metadata` module to `v04.zarr_metadata` module. This breaks bioio.ome_tiff_writer`