### PR TITLE
Update image_overview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "bioio-ome-zarr>=1",
     "bioio-nd2>=1",
     "bioio-base>=1.0.4",
+    "matplotlib-scalebar>=0.8.1",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ dependencies = [
     "bioio-tifffile>=1",
     "bioio-imageio>=1",
     "bioio-ome-zarr>=1",
-    "bioio-nd2>=1"
+    "bioio-nd2>=1",
+    "bioio-base>=1.0.4",
 ]
 dynamic = ["version"]
 

--- a/src/napari_ndev/_tests/test_image_overview.py
+++ b/src/napari_ndev/_tests/test_image_overview.py
@@ -3,14 +3,14 @@ import pathlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from bioio import BioImage
 
+from napari_ndev import nImage
 from napari_ndev.image_overview import ImageOverview, image_overview
 
 
 @pytest.fixture
 def image_and_label_sets():
-    img = BioImage(
+    img = nImage(
         pathlib.Path(
             r'src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
         )
@@ -23,7 +23,7 @@ def image_and_label_sets():
         'title': ['Image 1', 'Image 2'],
     }
 
-    lbl = BioImage(
+    lbl = nImage(
         pathlib.Path(
             r'src/napari_ndev/_tests/resources/Workflow/Labels/cells3d2ch.tiff'
         )

--- a/src/napari_ndev/_tests/test_image_overview.py
+++ b/src/napari_ndev/_tests/test_image_overview.py
@@ -59,7 +59,7 @@ def test_image_overview(image_and_label_sets):
     assert fig.axes[3].get_title() == 'Labels'
 
 def test_image_overview_plot_scale(image_and_label_sets):
-    fig = image_overview(image_and_label_sets, plot_scale=(5, 6))
+    fig = image_overview(image_and_label_sets, fig_scale=(5, 6))
 
     assert isinstance(fig, plt.Figure)
     assert np.array_equal(
@@ -68,7 +68,7 @@ def test_image_overview_plot_scale(image_and_label_sets):
 
 def test_image_overview_plot_title(image_and_label_sets):
     test_title = 'Test title'
-    fig = image_overview(image_and_label_sets, plot_title=test_title)
+    fig = image_overview(image_and_label_sets, fig_title=test_title)
 
     assert isinstance(fig, plt.Figure)
     assert fig._suptitle.get_text() == test_title

--- a/src/napari_ndev/_tests/test_image_overview.py
+++ b/src/napari_ndev/_tests/test_image_overview.py
@@ -3,6 +3,7 @@ import pathlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib_scalebar.scalebar import ScaleBar
 
 from napari_ndev import nImage
 from napari_ndev.image_overview import ImageOverview, image_overview
@@ -56,6 +57,58 @@ def test_image_overview(image_and_label_sets):
     assert not fig.axes[2].get_images()
 
     assert fig.axes[3].get_title() == 'Labels'
+
+def test_image_overview_plot_scale(image_and_label_sets):
+    fig = image_overview(image_and_label_sets, plot_scale=(5, 6))
+
+    assert isinstance(fig, plt.Figure)
+    assert np.array_equal(
+        fig.get_size_inches(), np.array([10, 12])
+    ) # 2 columns * 5 width, 2 rows * 6 height
+
+def test_image_overview_plot_title(image_and_label_sets):
+    test_title = 'Test title'
+    fig = image_overview(image_and_label_sets, plot_title=test_title)
+
+    assert isinstance(fig, plt.Figure)
+    assert fig._suptitle.get_text() == test_title
+
+def test_image_overview_scalebar_float(image_and_label_sets):
+    fig = image_overview(image_and_label_sets, scalebar=0.5)
+
+    assert isinstance(fig, plt.Figure)
+
+    scalebar_list = []
+    for ax in fig.axes:
+        scalebar = [
+            child for child in ax.get_children()
+            if isinstance(child, ScaleBar)
+        ]
+        scalebar_list.append(scalebar)
+
+    assert len(scalebar_list) == 4
+    assert len(scalebar_list[0]) == 1
+    assert len(scalebar_list[1]) == 1
+    assert len(scalebar_list[2]) == 0 # has no ax to add scalebar to
+    assert len(scalebar_list[3]) == 1
+
+def test_image_overview_scalebar_dict(image_and_label_sets):
+    scalebar_dict = {
+        'dx': 0.5,
+        'units': 'mm',
+        'location': 'upper right',
+        'badkey': 'badvalue',
+    }
+    fig = image_overview(image_and_label_sets, scalebar=scalebar_dict)
+
+    assert isinstance(fig, plt.Figure)
+
+    # get scalebar from the first axis, multi-axes tested in float
+    scalebar = [
+        child for child in fig.axes[0].get_children()
+        if isinstance(child, ScaleBar)
+    ]
+    assert len(scalebar) == 1
 
 
 def test_imageoverview_init(image_and_label_sets):

--- a/src/napari_ndev/image_overview.py
+++ b/src/napari_ndev/image_overview.py
@@ -181,7 +181,7 @@ def image_overview(
                 axs[row][col].add_artist(ScaleBar(**sb_dict))
 
     plt.suptitle(plot_title, fontsize=16)
-    plt.tight_layout()
+    plt.tight_layout(pad=0.3)
     # plt.subplots_adjust(wspace=0.1, hspace=0.1)
 
     return fig

--- a/src/napari_ndev/image_overview.py
+++ b/src/napari_ndev/image_overview.py
@@ -84,8 +84,7 @@ class ImageOverview:
 
 def image_overview(
     image_sets: dict | list[dict],
-    xscale: float = 3,
-    yscale: float = 3,
+    plot_scale: tuple[float, float] = (3, 3),
     plot_title: str = '',
     scalebar: float | dict | None = None,
 ):
@@ -103,10 +102,10 @@ def image_overview(
             "labels" will display the image as labels.
         - labels (list of bool, optional): Whether to display labels.
         - **kwargs: Additional keyword arguments to pass to stackview.imshow.
-    xscale : float, optional
-        The x scale of the overview. Defaults to 3.
-    yscale : float, optional
-        The y scale of the overview. Defaults to 3.
+    plot_scale : tuple of float, optional
+        The scale of the plot. (Width, Height). Values lower than 2 are likely
+        to result in overlapping text. Increased values increase image size.
+        Defaults to (3, 3).
     plot_title : str, optional
         The title of the plot. Defaults to an empty string.
     scalebar : float or dict, optional
@@ -125,10 +124,11 @@ def image_overview(
     # create the subplot grid
     num_rows = len(image_sets)
     num_columns = max([len(image_set['image']) for image_set in image_sets])
+    # multiply scale of plot by number of columns and rows
     fig, axs = plt.subplots(
         num_rows,
         num_columns,
-        figsize=(num_columns * xscale, num_rows * yscale),
+        figsize=(num_columns * plot_scale[0], num_rows * plot_scale[1]),
     )
 
     if num_rows == 1:

--- a/src/napari_ndev/image_overview.py
+++ b/src/napari_ndev/image_overview.py
@@ -23,7 +23,7 @@ class ImageOverview:
 
     def __init__(
         self,
-        image_sets: list[dict],
+        image_sets: dict | list[dict],
         xscale: float = 3,
         yscale: float = 3,
         image_title: str = '',
@@ -81,7 +81,7 @@ class ImageOverview:
 
 
 def image_overview(
-    image_sets: list[dict],
+    image_sets: dict | list[dict],
     xscale: float = 3,
     yscale: float = 3,
     plot_title: str = '',
@@ -113,6 +113,8 @@ def image_overview(
         The matplotlib figure object containing the image overview.
 
     """
+    # convert input to list if needed
+    image_sets = [image_sets] if isinstance(image_sets, dict) else image_sets
     # create the subplot grid
     num_rows = len(image_sets)
     num_columns = max([len(image_set['image']) for image_set in image_sets])

--- a/src/napari_ndev/image_overview.py
+++ b/src/napari_ndev/image_overview.py
@@ -26,9 +26,9 @@ class ImageOverview:
     def __init__(
         self,
         image_sets: dict | list[dict],
-        xscale: float = 3,
-        yscale: float = 3,
-        image_title: str = '',
+        plot_scale: tuple[float, float] = (3, 3),
+        plot_title: str = '',
+        scalebar: float | dict | None = None,
         show: bool = False,
     ):
         """
@@ -39,19 +39,23 @@ class ImageOverview:
         image_sets : list of dict
             A list of dictionaries containing image sets. See
             `napari_ndev.image_overview` for more information.
-        xscale : float, optional
-            The scale factor for the x-axis. Default is 3.
-        yscale : float, optional
-            The scale factor for the y-axis. Default is 3.
-        image_title : str, optional
+        plot_scale : tuple of float, optional
+            The scale of the plot. (Width, Height). Values lower than 2 are likely
+            to result in overlapping text. Increased values increase image size.
+            Defaults to (3, 3).
+        plot_title : str, optional
             The title of the image overview. Default is an empty string.
+        scalebar : float or dict, optional
+            The scalebar to add to the image overview. If a float, it is used as
+            the dx parameter for the scalebar. If a dict, all **kwargs are passed
+            to the matplotlib_scalebar.scalebar.ScaleBar class. Defaults to None.
         show : bool, optional
             Whether to display the generated overview. Default is False.
             Prevents memory leak when False.
 
         """
         plt.ioff()
-        self.fig = image_overview(image_sets, xscale, yscale, image_title)
+        self.fig = image_overview(image_sets, plot_scale, plot_title, scalebar)
         if show:
             plt.show()
         plt.close()
@@ -182,6 +186,5 @@ def image_overview(
 
     plt.suptitle(plot_title, fontsize=16)
     plt.tight_layout(pad=0.3)
-    # plt.subplots_adjust(wspace=0.1, hspace=0.1)
 
     return fig

--- a/src/napari_ndev/image_overview.py
+++ b/src/napari_ndev/image_overview.py
@@ -26,8 +26,8 @@ class ImageOverview:
     def __init__(
         self,
         image_sets: dict | list[dict],
-        plot_scale: tuple[float, float] = (3, 3),
-        plot_title: str = '',
+        fig_scale: tuple[float, float] = (3, 3),
+        fig_title: str = '',
         scalebar: float | dict | None = None,
         show: bool = False,
     ):
@@ -39,11 +39,11 @@ class ImageOverview:
         image_sets : list of dict
             A list of dictionaries containing image sets. See
             `napari_ndev.image_overview` for more information.
-        plot_scale : tuple of float, optional
+        fig_scale : tuple of float, optional
             The scale of the plot. (Width, Height). Values lower than 2 are likely
             to result in overlapping text. Increased values increase image size.
             Defaults to (3, 3).
-        plot_title : str, optional
+        fig_title : str, optional
             The title of the image overview. Default is an empty string.
         scalebar : float or dict, optional
             The scalebar to add to the image overview. If a float, it is used as
@@ -55,7 +55,7 @@ class ImageOverview:
 
         """
         plt.ioff()
-        self.fig = image_overview(image_sets, plot_scale, plot_title, scalebar)
+        self.fig = image_overview(image_sets, fig_scale, fig_title, scalebar)
         if show:
             plt.show()
         plt.close()
@@ -88,8 +88,8 @@ class ImageOverview:
 
 def image_overview(
     image_sets: dict | list[dict],
-    plot_scale: tuple[float, float] = (3, 3),
-    plot_title: str = '',
+    fig_scale: tuple[float, float] = (3, 3),
+    fig_title: str = '',
     scalebar: float | dict | None = None,
 ):
     """
@@ -106,11 +106,11 @@ def image_overview(
             "labels" will display the image as labels.
         - labels (list of bool, optional): Whether to display labels.
         - **kwargs: Additional keyword arguments to pass to stackview.imshow.
-    plot_scale : tuple of float, optional
+    fig_scale : tuple of float, optional
         The scale of the plot. (Width, Height). Values lower than 2 are likely
         to result in overlapping text. Increased values increase image size.
         Defaults to (3, 3).
-    plot_title : str, optional
+    fig_title : str, optional
         The title of the plot. Defaults to an empty string.
     scalebar : float or dict, optional
         The scalebar to add to the image overview. If a float, it is used as
@@ -132,7 +132,7 @@ def image_overview(
     fig, axs = plt.subplots(
         num_rows,
         num_columns,
-        figsize=(num_columns * plot_scale[0], num_rows * plot_scale[1]),
+        figsize=(num_columns * fig_scale[0], num_rows * fig_scale[1]),
     )
 
     if num_rows == 1:
@@ -184,7 +184,7 @@ def image_overview(
 
                 axs[row][col].add_artist(ScaleBar(**sb_dict))
 
-    plt.suptitle(plot_title, fontsize=16)
+    plt.suptitle(fig_title, fontsize=16)
     plt.tight_layout(pad=0.3)
 
     return fig

--- a/uv.lock
+++ b/uv.lock
@@ -2619,6 +2619,18 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib-scalebar"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/16/a564e2c97652e95b5aca51f21e3b281a0546159a9a6b06e2f6476bc53da6/matplotlib-scalebar-0.8.1.tar.gz", hash = "sha256:14887af1093579c5e6afae51a0a1ecc3f715cdbc5c4d7ef59cdeec76ee6bb15d", size = 1108463 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/9e/22930e3deb2c374f47c6633aff9f6f379f8c421ab868fff3b4f85eac8b8a/matplotlib_scalebar-0.8.1-py2.py3-none-any.whl", hash = "sha256:a8a2f361d4c2d576d087df3092ed95cac2f708f8b40d5d2bb992bd190e740b3a", size = 17686 },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3101,11 +3113,12 @@ wheels = [
 
 [[package]]
 name = "napari-ndev"
-version = "0.9.7.dev4+gf619bf4.d20241209"
+version = "0.9.7.dev11+ge112221.d20241209"
 source = { editable = "." }
 dependencies = [
     { name = "apoc" },
     { name = "bioio" },
+    { name = "bioio-base" },
     { name = "bioio-imageio" },
     { name = "bioio-nd2" },
     { name = "bioio-ome-tiff" },
@@ -3114,6 +3127,7 @@ dependencies = [
     { name = "dask" },
     { name = "magic-class" },
     { name = "magicgui" },
+    { name = "matplotlib-scalebar" },
     { name = "napari", extra = ["all"] },
     { name = "napari-pyclesperanto-assistant" },
     { name = "napari-segment-blobs-and-things-with-membranes" },
@@ -3202,6 +3216,7 @@ testing = [
 requires-dist = [
     { name = "apoc" },
     { name = "bioio", specifier = ">=1.1.0" },
+    { name = "bioio-base", specifier = ">=1.0.4" },
     { name = "bioio-czi", marker = "extra == 'gpl-extras'", specifier = ">=1.0.1" },
     { name = "bioio-czi", marker = "extra == 'testing'", specifier = ">=1.0.1" },
     { name = "bioio-imageio", specifier = ">=1" },
@@ -3214,6 +3229,7 @@ requires-dist = [
     { name = "dask" },
     { name = "magic-class" },
     { name = "magicgui", specifier = ">=0.8.3" },
+    { name = "matplotlib-scalebar", specifier = ">=0.8.1" },
     { name = "mkdocs", marker = "extra == 'docs'" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'" },
     { name = "mkdocs-jupyter", marker = "extra == 'docs'" },


### PR DESCRIPTION
closes Issue #112 

* rename `fig_title` from `plot_title`
* rename `fig_scale` from `xscale` and `yscale`
* reduce padding (0.3, down from default 1.08) between axes
* adds scalebar! either pass a float representing px/um or pass a dict to act as kwargs to `matplotlib_scalebar.scalebar.Scalebar`
* should thoroughly test all these, including title and scale which were not previously tested