### PR TITLE
add back dict support for image overview

### DIFF
--- a/src/napari_ndev/_tests/test_image_overview.py
+++ b/src/napari_ndev/_tests/test_image_overview.py
@@ -9,6 +9,7 @@ from napari_ndev.image_overview import (
     ImageOverview,
     ImageSet,
     _add_scalebar,
+    _convert_dict_to_ImageSet,
     image_overview,
 )
 
@@ -259,3 +260,19 @@ def test_imageoverview_save(image_and_label_sets_ImageSet):
     assert save_file_path.exists()
     # remove the saved file
     save_file_path.unlink()
+
+def test_convert_dict_to_ImageSet():
+    image_data = np.random.rand(2, 100, 100)
+    image_set1 = {
+        'image': [image_data[0], image_data[1]],
+        'colormap': ['PiYG', 'viridis'],
+        'title': ['Image 1', 'Image 2'],
+        'labels': [False, False],
+        'min_display_intensity': [0, 0],
+        'max_display_intensity': [1, 1],
+    }
+
+    image_set = _convert_dict_to_ImageSet([image_set1])
+    assert isinstance(image_set, list)
+    assert isinstance(image_set[0], ImageSet)
+    assert isinstance(image_set[0].image, list)

--- a/src/napari_ndev/_tests/test_image_overview.py
+++ b/src/napari_ndev/_tests/test_image_overview.py
@@ -76,9 +76,31 @@ def test_image_overview_nowrap():
     assert len(fig.axes) == 3
     assert fig.axes[0].get_title() == 'Image 1'
 
+@pytest.fixture
+def image_and_label_sets_dict():
+    # create an img with shape 2 x 100 x 100
+    image_data = np.random.rand(2, 100, 100)
+    image_set1 = {
+        'image': [image_data[0], image_data[1]],
+        'colormap': ['PiYG', 'viridis'],
+        'title': ['Image 1', 'Image 2'],
+        'labels': [False, False],
+        'min_display_intensity': [0, 0],
+        'max_display_intensity': [1, 1],
+    }
+
+    # create a label image with only 1s and 0s with shape 100 x 100
+    label_data = np.random.randint(0, 2, (100, 100))
+    label_set = {
+        'image': [None, label_data],
+        'colormap': [None, 'Labels'], # tests the cmap.lower() component, this actually helped because it detected a lack of list
+        'title': [None, 'Labels'],
+    }
+
+    return image_set1, label_set
 
 @pytest.fixture
-def image_and_label_sets():
+def image_and_label_sets_ImageSet():
 
     # create an img with shape 2 x 100 x 100
     image_data = np.random.rand(2, 100, 100)
@@ -101,9 +123,9 @@ def image_and_label_sets():
 
     return image_set1, label_set
 
-
-def test_image_overview(image_and_label_sets):
-    fig = image_overview(image_and_label_sets)
+# test both the ImageSet and dictionary input
+def test_image_overview_dict(image_and_label_sets_dict):
+    fig = image_overview(image_and_label_sets_dict)
 
     assert isinstance(fig, plt.Figure)
     assert len(fig.axes) == 4
@@ -121,23 +143,42 @@ def test_image_overview(image_and_label_sets):
 
     assert fig.axes[3].get_title() == 'Labels'
 
-def test_image_overview_plot_scale(image_and_label_sets):
-    fig = image_overview(image_and_label_sets, fig_scale=(5, 6))
+def test_image_overview(image_and_label_sets_ImageSet):
+    fig = image_overview(image_and_label_sets_ImageSet)
+
+    assert isinstance(fig, plt.Figure)
+    assert len(fig.axes) == 4
+
+    # Check the properties of each subplot
+    assert fig.axes[0].get_title() == 'Image 1'
+    assert fig.axes[0].get_images()[0].get_cmap().name == 'PiYG'
+
+    assert fig.axes[1].get_title() == 'Image 2'
+    assert fig.axes[1].get_images()[0].get_cmap().name == 'viridis'
+
+    # fig. axes[2] should be empty
+    assert not fig.axes[2].get_title()
+    assert not fig.axes[2].get_images()
+
+    assert fig.axes[3].get_title() == 'Labels'
+
+def test_image_overview_plot_scale(image_and_label_sets_ImageSet):
+    fig = image_overview(image_and_label_sets_ImageSet, fig_scale=(5, 6))
 
     assert isinstance(fig, plt.Figure)
     assert np.array_equal(
         fig.get_size_inches(), np.array([10, 12])
     ) # 2 columns * 5 width, 2 rows * 6 height
 
-def test_image_overview_plot_title(image_and_label_sets):
+def test_image_overview_plot_title(image_and_label_sets_ImageSet):
     test_title = 'Test title'
-    fig = image_overview(image_and_label_sets, fig_title=test_title)
+    fig = image_overview(image_and_label_sets_ImageSet, fig_title=test_title)
 
     assert isinstance(fig, plt.Figure)
     assert fig._suptitle.get_text() == test_title
 
-def test_add_scalebar_float(image_and_label_sets):
-    fig = image_overview(image_and_label_sets)
+def test_add_scalebar_float(image_and_label_sets_ImageSet):
+    fig = image_overview(image_and_label_sets_ImageSet)
     _add_scalebar(fig.axes[0], 0.5)
 
     assert isinstance(fig, plt.Figure)
@@ -147,8 +188,8 @@ def test_add_scalebar_float(image_and_label_sets):
     ]
     assert len(scalebar) == 1
 
-def test_add_scalebar_dict(image_and_label_sets):
-    fig = image_overview(image_and_label_sets)
+def test_add_scalebar_dict(image_and_label_sets_ImageSet):
+    fig = image_overview(image_and_label_sets_ImageSet)
     scalebar_dict = {
         'dx': 0.25,
         'units': 'mm',
@@ -164,8 +205,8 @@ def test_add_scalebar_dict(image_and_label_sets):
     ]
     assert len(scalebar) == 1
 
-def test_image_overview_scalebar_float(image_and_label_sets):
-    fig = image_overview(image_and_label_sets, scalebar=0.5)
+def test_image_overview_scalebar_float(image_and_label_sets_ImageSet):
+    fig = image_overview(image_and_label_sets_ImageSet, scalebar=0.5)
 
     assert isinstance(fig, plt.Figure)
 
@@ -183,14 +224,14 @@ def test_image_overview_scalebar_float(image_and_label_sets):
     assert len(scalebar_list[2]) == 0 # has no ax to add scalebar to
     assert len(scalebar_list[3]) == 1
 
-def test_image_overview_scalebar_dict(image_and_label_sets):
+def test_image_overview_scalebar_dict(image_and_label_sets_ImageSet):
     scalebar_dict = {
         'dx': 0.5,
         'units': 'mm',
         'location': 'upper right',
         'badkey': 'badvalue',
     }
-    fig = image_overview(image_and_label_sets, scalebar=scalebar_dict)
+    fig = image_overview(image_and_label_sets_ImageSet, scalebar=scalebar_dict)
 
     assert isinstance(fig, plt.Figure)
 
@@ -202,13 +243,13 @@ def test_image_overview_scalebar_dict(image_and_label_sets):
     assert len(scalebar) == 1
 
 
-def test_imageoverview_init(image_and_label_sets):
-    im = ImageOverview(image_and_label_sets, show=False)
+def test_imageoverview_init(image_and_label_sets_ImageSet):
+    im = ImageOverview(image_and_label_sets_ImageSet, show=False)
     assert isinstance(im.fig, plt.Figure)
 
 
-def test_imageoverview_save(image_and_label_sets):
-    im = ImageOverview(image_and_label_sets, show=False)
+def test_imageoverview_save(image_and_label_sets_ImageSet):
+    im = ImageOverview(image_and_label_sets_ImageSet, show=False)
     # test that the figure can be saved with .save()
     save_path = pathlib.Path(r'src\napari_ndev\_tests\resources')
     save_file_path = save_path / 'image_overview.png'


### PR DESCRIPTION
Add dict support again for image overview, but add a DeprecationWarning. Intended to rely solely on ImageSet in the future, but there are plenty of scripts using `image_overivew()` which have dict inputs, since these don't have any sort of lock file, this keeps future support, at least until data is published with versioning. 