### PR TITLE
Use nImage for image/file handling throughout the code, instead of BioImage

### DIFF
--- a/docs/examples/skimage_workflow.ipynb
+++ b/docs/examples/skimage_workflow.ipynb
@@ -9,9 +9,10 @@
     "import napari_segment_blobs_and_things_with_membranes as nsbatwm\n",
     "import numpy as np\n",
     "import stackview\n",
-    "from bioio import BioImage\n",
     "from napari_workflows import Workflow\n",
-    "from napari_workflows._io_yaml_v1 import load_workflow, save_workflow\n"
+    "from napari_workflows._io_yaml_v1 import load_workflow, save_workflow\n",
+    "\n",
+    "from napari_ndev import nImage\n"
    ]
   },
   {
@@ -52,7 +53,7 @@
    "source": [
     "wf = load_workflow('cpu_workflow-2roots-2leafs.yaml')\n",
     "\n",
-    "img = BioImage(r'images\\cells3d2ch.tiff')\n",
+    "img = nImage(r'images\\cells3d2ch.tiff')\n",
     "membrane = img.get_image_data('TCZYX', C=0)\n",
     "membrane = np.squeeze(membrane)\n",
     "\n",
@@ -76,7 +77,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "bastian-lab",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -90,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/examples/workflow/workflow_scripting.ipynb
+++ b/docs/examples/workflow/workflow_scripting.ipynb
@@ -16,9 +16,10 @@
     "import napari_segment_blobs_and_things_with_membranes as nsbatwm\n",
     "import numpy as np\n",
     "import stackview\n",
-    "from bioio import BioImage\n",
     "from napari_workflows import Workflow\n",
-    "from napari_workflows._io_yaml_v1 import load_workflow, save_workflow\n"
+    "from napari_workflows._io_yaml_v1 import load_workflow, save_workflow\n",
+    "\n",
+    "from napari_ndev import nImage\n"
    ]
   },
   {
@@ -59,7 +60,7 @@
    "source": [
     "wf = load_workflow('cpu_workflow-2roots-2leafs.yaml')\n",
     "\n",
-    "img = BioImage(r'images\\cells3d2ch.tiff')\n",
+    "img = nImage(r'images\\cells3d2ch.tiff')\n",
     "membrane = img.get_image_data('TCZYX', C=0)\n",
     "membrane = np.squeeze(membrane)\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,12 @@ dependencies = [
     "scikit-image>=0.18.0",
     "ngff-zarr<0.10.0",
     "bioio>=1.1.0",
-    "bioio-ome-tiff>=1",
-    "bioio-tifffile>=1",
+    "bioio-base>=1.0.4",
     "bioio-imageio>=1",
+    "bioio-tifffile>=1",
+    "bioio-ome-tiff>=1",
     "bioio-ome-zarr>=1",
     "bioio-nd2>=1",
-    "bioio-base>=1.0.4",
     "matplotlib-scalebar>=0.8.1",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "stackview",
     "tifffile>=2023.3.15",
     "scikit-image>=0.18.0",
-    "ngff-zarr<0.10.0",
+    "ngff-zarr>0.10.0",
     "bioio>=1.1.0",
     "bioio-base>=1.0.4",
     "bioio-imageio>=1",

--- a/src/napari_ndev/_napari_reader.py
+++ b/src/napari_ndev/_napari_reader.py
@@ -5,7 +5,6 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
-from bioio import BioImage
 from bioio_base.exceptions import UnsupportedFileFormatError
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -66,7 +65,7 @@ def napari_get_reader(
             import bioio_ome_tiff
             reader = bioio_ome_tiff.Reader
         else:
-            plugin = BioImage.determine_plugin(path)
+            plugin = nImage.determine_plugin(path)
             reader = plugin.metadata.get_reader()
         # return napari_reader_function(path, reader, in_memory)
         return partial(

--- a/src/napari_ndev/_napari_reader.py
+++ b/src/napari_ndev/_napari_reader.py
@@ -59,8 +59,15 @@ def napari_get_reader(
         return None
 
     try:
-        plugin = BioImage.determine_plugin(path)
-        reader = plugin.metadata.get_reader()
+        # TODO: Test this if else functionality.
+        from bioio import plugin_feasibility_report as pfr
+        fr = pfr(path)
+        if 'bioio-ome-tiff' in fr and fr['bioio-ome-tiff'].supported:
+            import bioio_ome_tiff
+            reader = bioio_ome_tiff.Reader
+        else:
+            plugin = BioImage.determine_plugin(path)
+            reader = plugin.metadata.get_reader()
         # return napari_reader_function(path, reader, in_memory)
         return partial(
             napari_reader_function,

--- a/src/napari_ndev/_tests/test_helpers.py
+++ b/src/napari_ndev/_tests/test_helpers.py
@@ -12,18 +12,9 @@ from napari_ndev.helpers import (
     create_id_string,
     get_channel_names,
     get_directory_and_files,
-    get_Image,
     get_squeezed_dim_order,
     setup_logger,
 )
-
-
-def test_get_Image():
-    file = Path(
-        './src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
-    )
-    img = get_Image(file)
-    assert isinstance(img, BioImage)
 
 
 def test_check_for_missing_files_path(tmp_path):

--- a/src/napari_ndev/_tests/test_helpers.py
+++ b/src/napari_ndev/_tests/test_helpers.py
@@ -81,9 +81,7 @@ def test_create_id_string_ome_metadata_no_name(resources_dir: Path):
 
     identifier = file.stem
     id_string = create_id_string(img, identifier)
-    assert (
-        img._plugin.entrypoint.name == 'bioio-ome-tiff'
-    )  # this has no ome_metadata.images.name
+
     assert img.ome_metadata.images[0].name is None
     assert img.channel_names == ['membrane', 'nuclei']
     assert id_string == 'cells3d2ch__0__Image:0'

--- a/src/napari_ndev/_tests/test_helpers.py
+++ b/src/napari_ndev/_tests/test_helpers.py
@@ -7,6 +7,7 @@ import pytest
 from bioio import BioImage
 from bioio.writers import OmeTiffWriter
 
+from napari_ndev import nImage
 from napari_ndev.helpers import (
     check_for_missing_files,
     create_id_string,
@@ -59,14 +60,14 @@ def test_check_for_missing_file_str(tmp_path):
 
 
 def test_create_id_string():
-    img = BioImage(np.random.random((2, 2)))
+    img = nImage(np.random.random((2, 2)))
     identifier = 'test_id'
     id_string = create_id_string(img, identifier)
     assert id_string == 'test_id__0__Image:0'
 
 
 def test_create_id_string_no_id():
-    img = BioImage(np.random.random((2, 2)))
+    img = nImage(np.random.random((2, 2)))
     identifier = None
     id_string = create_id_string(img, identifier)
     assert id_string == 'None__0__Image:0'
@@ -77,7 +78,7 @@ def test_create_id_string_ome_metadata_no_name(resources_dir: Path):
         # './src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
         resources_dir / 'Workflow/Images/cells3d2ch.tiff'
     )
-    img = BioImage(file)
+    img = nImage(file)
 
     identifier = file.stem
     id_string = create_id_string(img, identifier)
@@ -96,7 +97,7 @@ def test_create_id_string_ometiffwriter_name(tmp_path):
         image_name='test_image',
     )
 
-    img = BioImage(tmp_path / 'test.tiff')
+    img = nImage(tmp_path / 'test.tiff')
     identifier = 'test_id'
 
     id_string = create_id_string(img, identifier)
@@ -108,13 +109,13 @@ def test_get_channel_names_CYX():
     file = Path(
         r'./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
     )
-    img = BioImage(file)
+    img = nImage(file)
     assert get_channel_names(img) == img.channel_names
 
 
 def test_get_channel_names_RGB():
     file = Path(r'./src/napari_ndev/_tests/resources/RGB.tiff')
-    img = BioImage(file)
+    img = nImage(file)
     assert get_channel_names(img) == ['red', 'green', 'blue']
 
 
@@ -150,13 +151,13 @@ def test_get_squeezed_dim_order_ZYX():
     file = Path(
         r'./src/napari_ndev/_tests/resources/Workflow/Images/cells3d2ch.tiff'
     )
-    img = BioImage(file)
+    img = nImage(file)
     assert get_squeezed_dim_order(img) == 'ZYX'
 
 
 def test_get_squeezed_dim_order_RGB():
     file = Path(r'./src/napari_ndev/_tests/resources/RGB.tiff')
-    img = BioImage(file)
+    img = nImage(file)
     assert get_squeezed_dim_order(img) == 'YX'
 
 

--- a/src/napari_ndev/_tests/test_helpers.py
+++ b/src/napari_ndev/_tests/test_helpers.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from bioio import BioImage
 from bioio.writers import OmeTiffWriter
 
 from napari_ndev import nImage

--- a/src/napari_ndev/_tests/test_napari_reader.py
+++ b/src/napari_ndev/_tests/test_napari_reader.py
@@ -17,7 +17,7 @@ RGB_TIFF = "RGB.tiff" # has two scense
 MULTISCENE_CZI = r"0T-4C-0Z-7pos.czi"
 # PNG_FILE = "example.png"
 # GIF_FILE = "example.gif"
-# OME_TIFF = "pipeline-4.ome.tiff"
+OME_TIFF = "cells3d2ch.tiff"
 
 ###############################################################################
 
@@ -127,3 +127,27 @@ def test_for_multiscene_widget(
             data, _, _ = reader(path)[0]
             assert isinstance(data, expected_dtype)
             assert data.shape == expected_shape
+
+def test_napari_get_reader_multi_path(resources_dir: Path) -> None:
+    # Get reader
+    reader = napari_get_reader(
+        [str(resources_dir / RGB_TIFF), str(resources_dir / MULTISCENE_CZI)],
+        in_memory=True,
+    )
+
+    # Check callable
+    assert reader is None
+
+def test_napari_get_reader_ome_override(resources_dir: Path) -> None:
+    reader = napari_get_reader(
+        str(resources_dir / OME_TIFF),
+    )
+
+    assert callable(reader)
+
+def test_napari_get_reader_unsupported(resources_dir: Path) -> None:
+    reader = napari_get_reader(
+        str(resources_dir / "measure_props_Labels.csv"),
+    )
+
+    assert reader is None

--- a/src/napari_ndev/_tests/widgets/test_apoc_container.py
+++ b/src/napari_ndev/_tests/widgets/test_apoc_container.py
@@ -216,8 +216,8 @@ def test_update_metadata_from_file():
         )
 
         # Mock the BioImage class to return sample channel names
-        with patch('bioio.BioImage') as BioImage:
-            BioImage.return_value.channel_names = ['C0', 'C1', 'C2']
+        with patch('napari_ndev.nImage') as nImage:
+            nImage.return_value.channel_names = ['C0', 'C1', 'C2']
 
             # Call the _update_metadata_from_file method
             wdg._update_metadata_from_file()

--- a/src/napari_ndev/_tests/widgets/test_measure_container.py
+++ b/src/napari_ndev/_tests/widgets/test_measure_container.py
@@ -1,8 +1,8 @@
 import pathlib
 
 import numpy as np
-from bioio import BioImage
 
+from napari_ndev import nImage
 from napari_ndev.widgets._measure_container import MeasureContainer
 
 
@@ -39,7 +39,7 @@ def test_update_dim_and_scales():
     )
     file_name = 'SPF-4MM-22 slide 9-S6_Top Slide_TR2_p00_0_A01f00d0.tiff'
     container = MeasureContainer()
-    img = BioImage(image_directory / file_name)
+    img = nImage(image_directory / file_name)
     container._update_dim_and_scales(img)
 
     assert container._scale_tuple.value == (1.0, 0.2634, 0.2634)

--- a/src/napari_ndev/_tests/widgets/test_workflow_container.py
+++ b/src/napari_ndev/_tests/widgets/test_workflow_container.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from napari_ndev import helpers
+from napari_ndev import helpers, nImage
 from napari_ndev.widgets._workflow_container import WorkflowContainer
 
 # from napari_workflows._io_yaml_v1 import load_workflow
@@ -92,7 +92,7 @@ def test_batch_workflow_leaf_tasks(tmp_path):
     assert output_folder.exists()
     assert (output_folder / 'cells3d2ch.tiff').exists()
 
-    img = helpers.get_Image(output_folder / 'cells3d2ch.tiff')
+    img = nImage(output_folder / 'cells3d2ch.tiff')
     assert len(img.channel_names) == 2
 
 def test_batch_workflow_keep_original_images(tmp_path):
@@ -120,7 +120,7 @@ def test_batch_workflow_keep_original_images(tmp_path):
     assert output_folder.exists()
     assert (output_folder / 'cells3d2ch.tiff').exists()
 
-    img = helpers.get_Image(output_folder / 'cells3d2ch.tiff')
+    img = nImage(output_folder / 'cells3d2ch.tiff')
     assert len(img.channel_names) == 4
 
 def test_batch_workflow_all_tasks(tmp_path):
@@ -149,5 +149,5 @@ def test_batch_workflow_all_tasks(tmp_path):
     assert output_folder.exists()
     assert (output_folder / 'cells3d2ch.tiff').exists()
 
-    img = helpers.get_Image(output_folder / 'cells3d2ch.tiff')
+    img = nImage(output_folder / 'cells3d2ch.tiff')
     assert len(img.channel_names) == 6

--- a/src/napari_ndev/_tests/widgets/test_workflow_container.py
+++ b/src/napari_ndev/_tests/widgets/test_workflow_container.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from napari_ndev import helpers, nImage
+from napari_ndev import nImage
 from napari_ndev.widgets._workflow_container import WorkflowContainer
 
 # from napari_workflows._io_yaml_v1 import load_workflow

--- a/src/napari_ndev/helpers.py
+++ b/src/napari_ndev/helpers.py
@@ -26,32 +26,9 @@ __all__ = [
     'create_id_string',
     'get_channel_names',
     'get_directory_and_files',
-    'get_Image',
     'get_squeezed_dim_order',
     'setup_logger',
 ]
-
-def get_Image(file: str | Path) -> BioImage:
-    """
-    Read the image file with BioImage.
-
-    Open the image file with BioImage.
-
-    Parameters
-    ----------
-    file : str or Path
-        The file path.
-
-    Returns
-    -------
-    BioImage
-        The image object.
-
-    """
-    from bioio import BioImage
-
-    return BioImage(file)
-
 
 def get_directory_and_files(
     dir_path: str | Path | None = None,

--- a/src/napari_ndev/helpers.py
+++ b/src/napari_ndev/helpers.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING, Union
 if TYPE_CHECKING:
     from bioio import BioImage
 
+    from napari_ndev import nImage
+
 __all__ = [
     'check_for_missing_files',
     'create_id_string',
@@ -91,7 +93,7 @@ def get_directory_and_files(
     return directory, files
 
 
-def get_channel_names(img: BioImage) -> list[str]:
+def get_channel_names(img: nImage | BioImage) -> list[str]:
     """
     Get the channel names from a BioImage object.
 
@@ -116,7 +118,7 @@ def get_channel_names(img: BioImage) -> list[str]:
 
 
 def get_squeezed_dim_order(
-    img: BioImage,
+    img: nImage | BioImage,
     skip_dims: list[str] | str | None = None,
 ) -> str:
     """
@@ -142,7 +144,7 @@ def get_squeezed_dim_order(
     )
 
 
-def create_id_string(img: BioImage, identifier: str) -> str:
+def create_id_string(img: nImage | BioImage, identifier: str) -> str:
     """
     Create an ID string for the given image.
 

--- a/src/napari_ndev/widgets/_apoc_container.py
+++ b/src/napari_ndev/widgets/_apoc_container.py
@@ -369,10 +369,10 @@ class ApocContainer(Container):
         self._image_layers.choices = self._filter_layers(layers.Image)
 
     def _update_metadata_from_file(self):
-        from bioio import BioImage
+        from napari_ndev import nImage
 
         _, files = helpers.get_directory_and_files(self._image_directory.value)
-        img = BioImage(files[0])
+        img = nImage(files[0])
         self._image_channels.choices = helpers.get_channel_names(img)
 
     def _update_channel_order(self):
@@ -489,8 +489,9 @@ class ApocContainer(Container):
         return channel_img
 
     def batch_train(self):
-        from bioio import BioImage
         from pyclesperanto_prototype import set_wait_for_kernel_finish
+
+        from napari_ndev import nImage
 
         image_directory, image_files = helpers.get_directory_and_files(
             self._image_directory.value
@@ -550,10 +551,10 @@ class ApocContainer(Container):
 
             logger.info('Training Image %d: %s', idx + 1, image_file.name)
 
-            img = BioImage(image_directory / image_file.name)
+            img = nImage(image_directory / image_file.name)
             channel_img = self._get_channel_image(img, channel_index_list)
 
-            lbl = BioImage(label_directory / image_file.name)
+            lbl = nImage(label_directory / image_file.name)
             label = lbl.get_image_data('TCZYX', C=0)
 
             # <- this is where setting up dask processing would be useful
@@ -586,9 +587,10 @@ class ApocContainer(Container):
         return None
 
     def batch_predict(self):
-        from bioio import BioImage
         from bioio.writers import OmeTiffWriter
         from pyclesperanto_prototype import set_wait_for_kernel_finish
+
+        from napari_ndev import nImage
 
         image_directory, image_files = helpers.get_directory_and_files(
             dir_path=self._image_directory.value,
@@ -629,7 +631,7 @@ class ApocContainer(Container):
         for idx, file in enumerate(image_files):
             logger.info('Predicting Image %d: %s', idx + 1, file.name)
 
-            img = BioImage(file)
+            img = nImage(file)
             channel_img = self._get_channel_image(img, channel_index_list)
             squeezed_dim_order = helpers.get_squeezed_dim_order(img)
 

--- a/src/napari_ndev/widgets/_measure_container.py
+++ b/src/napari_ndev/widgets/_measure_container.py
@@ -398,10 +398,10 @@ class MeasureContainer(Container):
         self, directory: str | None = None
     ) -> tuple[BioImage, pathlib.Path]:
         """Get the first image from a directory."""
-        from bioio import BioImage
+        from napari_ndev import nImage
 
         _, files = helpers.get_directory_and_files(directory)
-        return BioImage(files[0]), files[0]
+        return nImage(files[0]), files[0]
 
     def _update_dim_and_scales(self, img):
         """Update the dimensions and scales based on the image."""
@@ -470,10 +470,7 @@ class MeasureContainer(Container):
             The measurement results as a DataFrame.
 
         """
-        from bioio import BioImage
-
-        # from skimage import measure
-        from napari_ndev import measure as ndev_measure
+        from napari_ndev import measure as ndev_measure, nImage
 
         # get all the files in the label directory
         label_dir, label_files = helpers.get_directory_and_files(
@@ -550,7 +547,7 @@ class MeasureContainer(Container):
         for idx, file in enumerate(label_files):
             # TODO: Add scene processing
             logger.info('Processing file %s', file.name)
-            lbl = BioImage(label_dir / file.name)
+            lbl = nImage(label_dir / file.name)
             id_string = helpers.create_id_string(lbl, file.stem)
 
             # get the itnensity image only if the image directory is not empty
@@ -563,7 +560,7 @@ class MeasureContainer(Container):
                     )
                     self._progress_bar.value = idx + 1
                     continue
-                img = BioImage(image_path)
+                img = nImage(image_path)
             if self._region_directory.value:
                 region_path = region_dir / file.name
                 if not region_path.exists():
@@ -573,7 +570,7 @@ class MeasureContainer(Container):
                     )
                     self._progress_bar.value = idx + 1
                     continue
-                reg = BioImage(region_path)
+                reg = nImage(region_path)
 
             for scene_idx, scene in enumerate(lbl.scenes):
                 logger.info('Processing scene: %s :: %s', scene_idx, scene)

--- a/src/napari_ndev/widgets/_workflow_container.py
+++ b/src/napari_ndev/widgets/_workflow_container.py
@@ -15,7 +15,7 @@ from magicgui.widgets import (
 )
 from qtpy.QtWidgets import QTabWidget
 
-from napari_ndev import helpers
+from napari_ndev import helpers, nImage
 
 if TYPE_CHECKING:
     import napari
@@ -158,7 +158,7 @@ class WorkflowContainer(Container):
         self.image_dir, self.image_files = helpers.get_directory_and_files(
             self.image_directory.value,
         )
-        img = helpers.get_Image(self.image_files[0])
+        img = nImage(self.image_files[0])
 
         self._channel_names = helpers.get_channel_names(img)
 
@@ -237,7 +237,7 @@ class WorkflowContainer(Container):
 
         for idx_file, image_file in enumerate(image_files):
             logger.info('Processing %d: %s', idx_file + 1, image_file.name)
-            img = helpers.get_Image(image_file)
+            img = nImage(image_file)
 
             root_stack = []
             # get image corresponding to each root, and set it to the workflow


### PR DESCRIPTION
Closes #129 . Most importantly, overrides BioImage reader determination with ome-tiff, if appropriate