### PR TITLE
Fix group_and_agg_func string inputs breaking column names

### DIFF
--- a/src/napari_ndev/_tests/test_measure.py
+++ b/src/napari_ndev/_tests/test_measure.py
@@ -443,7 +443,7 @@ def test_group_and_agg_measurements_string_agg_func(sample_data):
     result_df = group_and_agg_measurements(
         sample_data,
         grouping_cols='id',
-        agg_cols=['area'],
+        agg_cols='area',
         agg_funcs='mean',
     )
 

--- a/src/napari_ndev/_tests/test_measure.py
+++ b/src/napari_ndev/_tests/test_measure.py
@@ -442,7 +442,7 @@ def test_group_and_agg_measurements_sample_data(sample_data):
 def test_group_and_agg_measurements_string_agg_func(sample_data):
     result_df = group_and_agg_measurements(
         sample_data,
-        grouping_cols=['id'],
+        grouping_cols='id',
         agg_cols=['area'],
         agg_funcs='mean',
     )

--- a/src/napari_ndev/_tests/test_measure.py
+++ b/src/napari_ndev/_tests/test_measure.py
@@ -439,6 +439,20 @@ def test_group_and_agg_measurements_sample_data(sample_data):
     assert result_df['intensity_mean_mean'].tolist() == [0.6, 0.7]
     assert result_df['intensity_mean_sum'].tolist() == [1.2, 1.4]
 
+def test_group_and_agg_measurements_string_agg_func(sample_data):
+    result_df = group_and_agg_measurements(
+        sample_data,
+        grouping_cols=['id'],
+        agg_cols=['area'],
+        agg_funcs='mean',
+    )
+
+    assert isinstance(result_df, pd.DataFrame)
+    assert all(
+        column in result_df.columns
+        for column in ['id', 'area_mean']
+    )
+
 def test_group_and_agg_measurements_real_data():
     df = pd.read_csv('src/napari_ndev/_tests/resources/measure_props_Labels.csv')
 

--- a/src/napari_ndev/measure.py
+++ b/src/napari_ndev/measure.py
@@ -184,6 +184,10 @@ def group_and_agg_measurements(
         The DataFrame with grouped and aggregated measurements.
 
     """
+    if isinstance(agg_funcs, str):
+        agg_funcs = [agg_funcs]
+    if isinstance(grouping_cols, str):
+        grouping_cols = [grouping_cols]
     # get count data
     df_count = (
             df.copy().groupby(grouping_cols)

--- a/src/napari_ndev/measure.py
+++ b/src/napari_ndev/measure.py
@@ -159,7 +159,7 @@ def group_and_agg_measurements(
     df: pd.DataFrame,
     grouping_cols: str | list[str] = 'id',
     count_col: str = 'label',
-    agg_cols: list[str] | None = None,
+    agg_cols: str | list[str] | None = None,
     agg_funcs: str | list[str] = 'mean',
 ) -> pd.DataFrame:
     """
@@ -184,10 +184,10 @@ def group_and_agg_measurements(
         The DataFrame with grouped and aggregated measurements.
 
     """
-    if isinstance(agg_funcs, str):
-        agg_funcs = [agg_funcs]
-    if isinstance(grouping_cols, str):
-        grouping_cols = [grouping_cols]
+    grouping_cols = _convert_to_list(grouping_cols)
+    agg_cols = _convert_to_list(agg_cols)
+    agg_funcs = _convert_to_list(agg_funcs)
+
     # get count data
     df_count = (
             df.copy().groupby(grouping_cols)


### PR DESCRIPTION
Uses helper function to convert string inputs to list, otherwise returns none. This prevents
![image](https://github.com/user-attachments/assets/a409a0d2-a1bf-41e6-a4cc-8c6bfe9b849d)

(where agg_funcs is implicitly 'mean' and not ['mean'] via default)