### PR TITLE
Update [dev] dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ A collection of widgets intended to serve any person seeking to process microsco
 
 ## [Check out the Docs to learn more!](https://timmonko.github.io/napari-ndev/)
 
-### See the [poster presented at BINA 2024](https://timmonko.github.io/napari-ndev/BINA_poster/) for an overview of the plugins in action!
+### See the [poster presented at BINA 2024](https://timmonko.github.io/napari-ndev/BINA_poster/) for an overview of the plugins in action
 
-### Try out the [Virtual I2K 2024 Workshop](https://timmonko.github.io/napari-ndev/tutorial/00_setup/) for an interactive tutorial!
+### Try out the [Virtual I2K 2024 Workshop](https://timmonko.github.io/napari-ndev/tutorial/00_setup/) for an interactive tutorial
 
 ## Installation
 
@@ -57,7 +57,7 @@ In addition, you may need to install specific [`bioio` readers](https://github.c
 
 ### Development Libraries
 
-For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests. You can also install `[dev-all]` to get all three of these dev dependencies.
+For development use the `[dev]` optional libraries to verify your changes, which includes the `[docs]` and `[testing]` optional groups. However, the Github-CI will test pull requests with `[testing]` only.
 
 ----------------------------------
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,7 @@ In addition, you may need to install specific [`bioio` readers](https://github.c
 
 ## Development Libraries
 
-For development use the `[dev]` optional libraries. You may also like to install `[docs]` and `[testing]` to verify your changes. However, `tox` will test any pull requests. You can also install `[dev-all]` to get all three of these dev dependencies.
+For development use the `[dev]` optional libraries to verify your changes, which includes the `[docs]` and `[testing]` optional groups. However, the Github-CI will test pull requests with `[testing]` only.
 
 ### Development with uv
 
@@ -73,10 +73,10 @@ You may use uv to set a certain python version, e.g.:
 uv pin python 3.11
 ```
 
-To use uv to install extras (like with `napari-ndev[dev-all]`), use:
+To use uv to install extras (like with `napari-ndev[dev]`), use:
 
 ```bash
-uv sync --extra dev-all
+uv sync --extra dev
 ```
 
 You may also test the tool version of uv during development with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,6 @@ testing = [
     "bioio-czi >= 1.0.1",
     "napari-ndev[extras]",
 ]
-dev = [
-    "ruff",
-    "pre-commit",
-]
 docs = [
     "mkdocs",
     "mkdocs-autorefs",
@@ -103,6 +99,12 @@ docs = [
     "mkdocs-table-reader-plugin",
     "black"
 ]
+dev = [
+    "ruff",
+    "pre-commit",
+    "napari-ndev[testing]",
+    "napari-ndev[docs]",
+]
 extras = [
     "napari-simpleitk-image-processing"
 ]
@@ -113,11 +115,6 @@ gpl_extras = [
 all = [
     "napari-ndev[extras]",
     "napari-ndev[gpl_extras]",
-]
-dev-all = [
-    "napari-ndev[dev]",
-    "napari-ndev[docs]",
-    "napari-ndev[testing]",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Removes [dev-all] dependency, because this was confusing. Now uses a simple [dev] optional dependency group to achieve the same thing, and as such [testing] can be separate for GithubCI testing and [docs] for pages deployment