### PR TITLE
add zarr FSStore compatability monkey patch for zarr>=3.0

### DIFF
--- a/src/napari_ndev/_tests/test_napari_reader.py
+++ b/src/napari_ndev/_tests/test_napari_reader.py
@@ -21,6 +21,20 @@ OME_TIFF = "cells3d2ch.tiff"
 
 ###############################################################################
 
+def test_napari_viewer_open(resources_dir: Path, make_napari_viewer) -> None:
+    """
+    Test that the napari viewer can open a file with the napari-ndev plugin.
+
+    In zarr>=3.0, the FSStore was removed and replaced with DirectoryStore.
+    This test checks that the napari viewer can open any file because BioImage
+    (nImage) would try to import the wrong FSStore from zarr. Now, the FSStore
+    is shimmed to DirectoryStore with a compatibility patch in nImage.
+    """
+    viewer = make_napari_viewer()
+    viewer.open(str(resources_dir / OME_TIFF), plugin='napari-ndev')
+
+    assert viewer.layers[0].data.shape == (60, 66, 85)
+
 @pytest.mark.parametrize(
     ("in_memory", "expected_dtype"),
     [

--- a/src/napari_ndev/_tests/test_nimage.py
+++ b/src/napari_ndev/_tests/test_nimage.py
@@ -10,27 +10,6 @@ from napari_ndev import nImage
 RGB_TIFF = "RGB.tiff"  # has two scenes
 CELLS3D2CH_OME_TIFF = "cells3d2ch.tiff"  # 2 channel, 3D OME-TIFF
 
-def test_apply_zarr_compat_patch():
-    import zarr
-
-    from napari_ndev.nimage import _apply_zarr_compat_patch
-
-    if hasattr(zarr.storage, 'FSStore'):
-        orig_fsstore = zarr.storage.FSStore
-        del zarr.storage.FSStore
-    else:
-        orig_fsstore = None
-
-    assert not hasattr(zarr.storage, 'FSStore')
-
-    _apply_zarr_compat_patch()
-
-    assert hasattr(zarr.storage, 'FSStore')
-
-    # restore original if it existed
-    if orig_fsstore is not None:
-        zarr.storage.FSStore = orig_fsstore
-
 def test_nImage_init(resources_dir: Path):
     img = nImage(resources_dir / RGB_TIFF)
     assert img.path == resources_dir / RGB_TIFF

--- a/src/napari_ndev/_tests/test_nimage.py
+++ b/src/napari_ndev/_tests/test_nimage.py
@@ -10,6 +10,25 @@ from napari_ndev import nImage
 RGB_TIFF = "RGB.tiff"  # has two scenes
 CELLS3D2CH_OME_TIFF = "cells3d2ch.tiff"  # 2 channel, 3D OME-TIFF
 
+def test_apply_zarr_compat_patch():
+    import zarr
+
+    from napari_ndev.nimage import _apply_zarr_compat_patch
+
+    if hasattr(zarr.storage, 'FSStore'):
+        orig_fsstore = zarr.storage.FSStore
+        del zarr.storage.FSStore
+    else:
+        orig_fsstore = None
+
+    _apply_zarr_compat_patch()
+
+    assert hasattr(zarr.storage, 'FSStore')
+
+    # restore original if it existed
+    if orig_fsstore is not None:
+        zarr.storage.FSStore = orig_fsstore
+
 def test_nImage_init(resources_dir: Path):
     img = nImage(resources_dir / RGB_TIFF)
     assert img.path == resources_dir / RGB_TIFF

--- a/src/napari_ndev/_tests/test_nimage.py
+++ b/src/napari_ndev/_tests/test_nimage.py
@@ -21,6 +21,8 @@ def test_apply_zarr_compat_patch():
     else:
         orig_fsstore = None
 
+    assert not hasattr(zarr.storage, 'FSStore')
+
     _apply_zarr_compat_patch()
 
     assert hasattr(zarr.storage, 'FSStore')

--- a/src/napari_ndev/nimage.py
+++ b/src/napari_ndev/nimage.py
@@ -25,8 +25,6 @@ def _apply_zarr_compat_patch():
     """Apply zarr compatibility patch for zarr>=3.0 with BioIO."""
     zarr_version = tuple(int(x) for x in zarr.__version__.split('.')[:2])
     if zarr_version >= (3, 0) and not hasattr(zarr.storage, 'FSStore'):
-        logger.debug("Applying zarr compatibility patch for zarr>=3.0")
-        # shim FFStore to redirect to DirectoryStore
         class FSStoreShim:
             def __new__(cls, *args, **kwargs):
                 return zarr.storage.directory.DirectoryStore(*args, **kwargs)

--- a/src/napari_ndev/nimage.py
+++ b/src/napari_ndev/nimage.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 
 import xarray as xr
+import zarr
 from bioio import BioImage
 from bioio_base.dimensions import DimensionNames
 from bioio_base.reader import Reader
@@ -19,6 +20,20 @@ from napari_ndev import get_settings
 logger = logging.getLogger(__name__)
 
 DELIM = " :: "
+
+def _apply_zarr_compat_patch():
+    """Apply zarr compatibility patch for zarr>=3.0 with BioIO."""
+    zarr_version = tuple(int(x) for x in zarr.__version__.split('.')[:2])
+    if zarr_version >= (3, 0) and not hasattr(zarr.storage, 'FSStore'):
+        logger.debug("Applying zarr compatibility patch for zarr>=3.0")
+        # shim FFStore to redirect to DirectoryStore
+        class FSStoreShim:
+            def __new__(cls, *args, **kwargs):
+                return zarr.storage.directory.DirectoryStore(*args, **kwargs)
+        # patch zarr.storage.FSStore to FFStoreShim
+        zarr.storage.FSStore = FSStoreShim
+
+_apply_zarr_compat_patch()
 
 class nImage(BioImage):
     """

--- a/src/napari_ndev/nimage.py
+++ b/src/napari_ndev/nimage.py
@@ -27,8 +27,7 @@ def _apply_zarr_compat_patch():
     if zarr_version >= (3, 0) and not hasattr(zarr.storage, 'FSStore'):
         class FSStoreShim:
             def __new__(cls, *args, **kwargs):
-                from zarr.storage.directory import DirectoryStore
-                return DirectoryStore(*args, **kwargs)
+                return zarr.storage.directory.DirectoryStore(*args, **kwargs)
         # patch zarr.storage.FSStore to FFStoreShim
         zarr.storage.FSStore = FSStoreShim
 

--- a/src/napari_ndev/nimage.py
+++ b/src/napari_ndev/nimage.py
@@ -27,7 +27,8 @@ def _apply_zarr_compat_patch():
     if zarr_version >= (3, 0) and not hasattr(zarr.storage, 'FSStore'):
         class FSStoreShim:
             def __new__(cls, *args, **kwargs):
-                return zarr.storage.directory.DirectoryStore(*args, **kwargs)
+                from zarr.storage.directory import DirectoryStore
+                return DirectoryStore(*args, **kwargs)
         # patch zarr.storage.FSStore to FFStoreShim
         zarr.storage.FSStore = FSStoreShim
 


### PR DESCRIPTION
- adds monkey patch to shim FSStore
- adds test that fails on main (opening an image with viewer.open) that passes only with this shim intact with zarr>3