### PR TITLE
add prereleases action cron job and fail template

### DIFF
--- a/.github/TEST_FAIL_TEMPLATE.md
+++ b/.github/TEST_FAIL_TEMPLATE.md
@@ -4,7 +4,7 @@ labels: [bug]
 ---
 The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
 
-The most recent failing test was on {{ env.PLATFORM }} py{{ env.PYTHON }} {{ env.BACKEND }}
+The most recent failing test was on {{ env.PLATFORM }} py{{ env.PYTHON_VERSION }}
 with commit: {{ sha }}
 
 Full run: https://github.com/TimMonko/napari-ndev/actions/runs/{{ env.RUN_ID }}

--- a/.github/TEST_FAIL_TEMPLATE.md
+++ b/.github/TEST_FAIL_TEMPLATE.md
@@ -1,0 +1,12 @@
+---
+title: "{{ env.TITLE }}"
+labels: [bug]
+---
+The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
+
+The most recent failing test was on {{ env.PLATFORM }} py{{ env.PYTHON }} {{ env.BACKEND }}
+with commit: {{ sha }}
+
+Full run: https://github.com/TimMonko/napari-ndev/actions/runs/{{ env.RUN_ID }}
+
+(This post will be updated if another test fails, as long as this issue remains open.)

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,13 +33,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          miniconda-version: latest
-          channels: conda-forge
-          channel-priority: strict
           python-version: ${{ matrix.python-version }}
+          cache-dependency-path: pyproject.toml
 
       # these libraries enable testing on Qt on linux
       - name: Enable Qt on Linux
@@ -58,14 +56,13 @@ jobs:
       # tox-conda: https://github.com/tox-dev/tox-conda
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools tox tox-gh-actions codecov
+          pip install --upgrade pip
+          pip install setuptools tox tox-gh-actions codecov
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
         uses: aganders3/headless-gui@v2
         with:
-          shell: bash -el {0}
           run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -1,0 +1,74 @@
+# An "early warning" cron job that will install dependencies
+# with `pip install --pre` periodically to test for breakage
+# (and open an issue if a test fails)
+name: --pre Test
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Check daily at midnight UTC
+  workflow_dispatch: # Allows triggering manually from Actions tab
+  pull_request:
+    paths:
+        - '.github/workflows/test_prereleases.yml'
+        - 'pyproject.toml'
+
+jobs:
+  test:
+    name: ${{ matrix.platform }} py${{ matrix.python-version }} --pre
+    runs-on: ${{ matrix.platform }}
+    strategy:
+        fail-fast: false
+        matrix:
+            platform: [ubuntu-latest, windows-latest]
+            python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up Conda
+          uses: conda-incubator/setup-miniconda@v3
+          with:
+              miniconda-version: latest
+              channels: conda-forge
+              channel-priority: strict
+              python-version: ${{ matrix.python-version }}
+
+        # these libraries enable testing on Qt on linux
+        - name: Enable Qt on Linux
+          uses: tlambert03/setup-qt-libs@v1
+
+        # strategy borrowed from vispy for installing opengl libs on windows
+        - name: Install Windows OpenGL
+          if: runner.os == 'Windows'
+          run: |
+            git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
+            powershell gl-ci-helpers/appveyor/install_opengl.ps1
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install setuptools tox tox-gh-actions codecov
+
+        - name: Test --pre with tox
+          uses: aganders3/headless-gui@v2
+          with:
+            run: python -m tox -v --pre
+          env:
+            PLATFORM: ${{ matrix.platform }}
+            PYTHON_VERSION: ${{ matrix.python-version }}
+        
+        - name: Report Failures
+          if: ${{ failure() && github.event_name == 'schedule' }}
+          uses: JasonEtco/create-an-issue@v2
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            PLATFORM: ${{ matrix.platform }}
+            PYTHON_VERSION: ${{ matrix.python-version }}
+            RUN_ID: ${{ github.run_id }}
+            TITLE: '[test-bot] pip install --pre is failing'
+          with:
+            filename: .github/TEST_FAIL_TEMPLATE.md
+            update_existing: true
+
+

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -17,59 +17,57 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }} --pre
     runs-on: ${{ matrix.platform }}
     strategy:
-        fail-fast: false
-        matrix:
-            platform: [ubuntu-latest, windows-latest]
-            python-version: ['3.9', '3.10', '3.11', '3.12']
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-        - name: Checkout
-          uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-        - name: Set up Conda
-          uses: conda-incubator/setup-miniconda@v3
-          with:
-              miniconda-version: latest
-              channels: conda-forge
-              channel-priority: strict
-              python-version: ${{ matrix.python-version }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-dependency-path: pyproject.toml
 
-        # these libraries enable testing on Qt on linux
-        - name: Enable Qt on Linux
-          uses: tlambert03/setup-qt-libs@v1
+      # these libraries enable testing on Qt on linux
+      - name: Enable Qt on Linux
+        uses: tlambert03/setup-qt-libs@v1
 
-        # strategy borrowed from vispy for installing opengl libs on windows
-        - name: Install Windows OpenGL
-          if: runner.os == 'Windows'
-          run: |
-            git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-            powershell gl-ci-helpers/appveyor/install_opengl.ps1
-          shell: powershell
+      # strategy borrowed from vispy for installing opengl libs on windows
+      - name: Install Windows OpenGL
+        if: runner.os == 'Windows'
+        run: |
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
+          powershell gl-ci-helpers/appveyor/install_opengl.ps1
+        shell: powershell
 
-        - name: Install dependencies
-          run: |
-            pip install --upgrade pip
-            pip install setuptools tox tox-gh-actions
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install setuptools tox tox-gh-actions
 
-        - name: Test --pre with tox
-          uses: aganders3/headless-gui@v2
-          with:
-            run: python -m tox -v --pre
-          env:
-            PLATFORM: ${{ matrix.platform }}
-            PYTHON_VERSION: ${{ matrix.python-version }}
+      - name: Test --pre with tox
+        uses: aganders3/headless-gui@v2
+        with:
+          run: python -m tox -v --pre
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
         
-        - name: Report Failures
-          if: ${{ failure() && github.event_name == 'schedule' }}
-          uses: JasonEtco/create-an-issue@v2
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            PLATFORM: ${{ matrix.platform }}
-            PYTHON_VERSION: ${{ matrix.python-version }}
-            RUN_ID: ${{ github.run_id }}
-            TITLE: '[test-bot] pip install --pre is failing'
-          with:
-            filename: .github/TEST_FAIL_TEMPLATE.md
-            update_existing: true
+      - name: Report Failures
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLATFORM: ${{ matrix.platform }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: '[test-bot] pip install --pre is failing'
+        with:
+          filename: .github/TEST_FAIL_TEMPLATE.md
+          update_existing: true
 
 

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -44,11 +44,12 @@ jobs:
           run: |
             git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
             powershell gl-ci-helpers/appveyor/install_opengl.ps1
+          shell: powershell
 
         - name: Install dependencies
           run: |
-            python -m pip install --upgrade pip
-            python -m pip install setuptools tox tox-gh-actions codecov
+            pip install --upgrade pip
+            pip install setuptools tox tox-gh-actions
 
         - name: Test --pre with tox
           uses: aganders3/headless-gui@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,6 @@ dependencies = [
     "bioio-ome-tiff>=1",
     "bioio-ome-zarr>=1",
     "bioio-nd2>=1",
-    "bioio-czi>=1.0.1",
-    "bioio-lif>=1",
     "matplotlib-scalebar>=0.8.1",
 ]
 dynamic = ["version"]
@@ -84,7 +82,7 @@ testing = [
     "pytest-qt",
     "napari[all]",
     "pyqt5",
-    "bioio-czi >= 1.0.1",
+    "bioio-czi>=1.0.1",
     "napari-ndev[extras]",
 ]
 docs = [
@@ -114,7 +112,6 @@ pyqt6 = [
 ]
 pyqt5 = [
     "napari[pyqt5]",
-    "pyqt5-qt5==5.15.2 ; platform_system == 'Windows'", # 5.15.2 is latest to build on windows, required for uv compatability
 ]
 pyside = [
     "napari[pyside]"
@@ -123,8 +120,8 @@ extras = [
     "napari-simpleitk-image-processing"
 ]
 gpl_extras = [
-    "bioio-czi >= 1.0.1",
-    "bioio-lif >= 1"
+    "bioio-czi>=1.0.1",
+    "bioio-lif>=1"
 ]
 all = [
     "napari-ndev[qtpy-backend]",


### PR DESCRIPTION
adds a job that runs every day at midnight UTC to test against pre-releases. This will try to detect breaks from dependencies before they occur. 