### PR TITLE
Separate test and release workflows

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,39 +1,33 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-name: Test
+name: Create Release
 
 on:
-  push:
-    branches: [main]
-    tags: ["v*"] # Push events to matching v*, i.e. v1.0, v20.15.10
-  pull_request:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/reusable_run_tox_test.yml
-    with:
-      coverage: true
-
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
     # and requires that you have put your twine API key in your
     # github secrets (see readme for details)
-    needs: [test]
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'tags')
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'v') }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -U setuptools setuptools_scm wheel twine build
+
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,3 +1,9 @@
+# This workflow is triggered when a commit is tagged with "v*"
+# and when the "Test" workflow completes successfully.
+# It builds the package and uploads it to PyPI using Twine.
+# It requires a Twine API key stored in GitHub secrets.
+# For more information see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+
 name: Create Release
 
 on:
@@ -9,11 +15,8 @@ on:
 
 jobs:
   deploy:
-    # this will run when you have tagged a commit, starting with "v*"
-    # and requires that you have put your twine API key in your
-    # github secrets (see readme for details)
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'v') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -1,0 +1,18 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Test
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"] # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable_run_tox_test.yml
+    with:
+      coverage: true

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -1,5 +1,5 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow runs tests for the project on different events such as push, pull request, or manual dispatch.
+# For more information see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 
 name: Test
 


### PR DESCRIPTION
Refactor the GitHub Actions workflows to separate the test and release processes, ensuring clearer execution flow and improved maintainability. Update descriptions and tag checks for better clarity.