### PR TITLE
Fix release workflow and add OIDC token permissions

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       coverage: true
 
-  deploy:
+  build:
     runs-on: ubuntu-latest
     if: |
       success() &&
@@ -45,5 +45,5 @@ jobs:
           python -m build .
 
       - name: Upload to PyPI
-        uses: pypa/gh-actions-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -24,6 +24,12 @@ jobs:
       success() &&
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v')
+
+    # Add permission for OIDC token
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -7,16 +7,23 @@
 name: Create Release
 
 on:
-  workflow_run:
-    workflows: ["Test"]
-    types: [completed]
-    branches: [main]
-  workflow_dispatch:
+  push:
+    tags: ["v*"] # Trigger on tags matching v*, e.g., v1.0, v20.15.10
+  pull_request:
+    paths: [.github/workflows/make_release.yml]
 
 jobs:
+  test:
+    uses: ./.github/workflows/reusable_run_tox_test.yml
+    with:
+      coverage: true
+
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v') }}
+    if: |
+      success() &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -39,16 +39,11 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install dependencies
+      - name: Build package
         run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine build
-
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
-        run: |
-          git tag
+          python -m pip install --upgrade pip build
           python -m build .
-          twine upload dist/*
+
+      - name: Upload to PyPI
+        uses: pypa/gh-actions-pypi-publish@release/v1
+

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -6,7 +6,6 @@ name: Test
 on:
   push:
     branches: [main]
-    tags: ["v*"] # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Gets rid of TWINE API key